### PR TITLE
Separate changesets base branch from PR target branch

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -92,8 +92,9 @@ steps:
 | `use-changesets`               | `true`                                       | Toggle changesets/action                         |
 | `changesets-title`             | `Release v\${{ env.NEW_VERSION }}`           | Title for release PR                             |
 | `changesets-commit`            | `Release v\${{ env.NEW_VERSION }}`           | Commit message                                   |
+| `changesets-base-branch`       | `main`                                       | Base branch for changesets version comparison    |
 | `open-pr-to-base`              | `true`                                       | Open PR back to base after publish               |
-| `pr-base`                      | `main`                                       | Base branch                                      |
+| `pr-base`                      | `main`                                       | Target branch for back-merge PR                  |
 | `pr-title`                     | `Merge \${{ github.ref_name }} back to main` | Back-merge PR title                              |
 | `pr-body`                      | `Auto-generated after publishing.`           | Back-merge PR body                               |
 | `working-directory`            |                                              | Directory to run commands in                     |

--- a/release/action.yml
+++ b/release/action.yml
@@ -76,18 +76,24 @@ inputs:
         default: "Release"
         required: false
 
+    # Changesets base branch
+    changesets-base-branch:
+        description: "Base branch for changesets to fetch and compare against (usually main/master)"
+        default: "main"
+        required: false
+
     # PR back to base branch after publish
     open-pr-to-base:
         description: "Open a PR from release branch back to base after a successful publish"
         default: "true"
         required: false
     pr-base:
-        description: "Base branch to merge into (e.g. main)"
+        description: "Target branch to merge the release branch into (e.g. main for production releases, next for pre-releases)"
         default: "main"
         required: false
     pr-title:
         description: "Title for the back-merge PR"
-        default: "Merge ${{ github.ref_name }} back to main"
+        default: "Merge ${{ github.ref_name }} back to ${{ inputs.pr-base }}"
         required: false
     pr-body:
         description: "Body for the back-merge PR"
@@ -128,7 +134,7 @@ runs:
           run: |
               git config --global user.email "github-actions[bot]@users.noreply.github.com"
               git config --global user.name "github-actions[bot]"
-              git fetch origin ${{ inputs.pr-base }}:${{ inputs.pr-base }}
+              git fetch origin ${{ inputs.changesets-base-branch }}:${{ inputs.changesets-base-branch }}
 
         - name: Setup pnpm
           uses: pnpm/action-setup@v4


### PR DESCRIPTION
Previously, the action used a single `pr-base` input for both:
1. Fetching the base branch for changesets version comparison
2. Setting the target branch for PR creation after release

This caused issues in workflows with multiple release branches (e.g., main → release for production, next → pre-release for beta releases). When merging next → pre-release, changesets would incorrectly fetch the `next` branch instead of the actual base branch (`main`) for version comparison, leading to failed version detection.

This change separates these concerns by adding a dedicated `changesets-base-branch` input, allowing changesets to always fetch the correct base branch while still supporting flexible PR target branches for different release workflows.