### PR TITLE
Add support for readonly pnpm cache in the `setup`

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -18,6 +18,7 @@ It handles environment setup, dependency installation, caching, and optional bui
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `node-version` | The version of Node.js to use. Default is `20`.                                                                                  |
 | `pnpm-version` | The version of pnpm to use. Default is `9.0.6`.                                                                                  |
+| `pnpm-cache`   | Cache strategy can be one of `read`, `write`, or `off`. Default is `write`                                                       |
 | `npm-token`    | NPM token for authenticating to the NPM registry. Required if installing from private packages.                                  |
 | `install`      | Either `"false"` to skip installing dependencies, or the install command to run. Default is `pnpm install --no-frozen-lockfile`. |
 | `build`        | Either `"false"` to skip building, or the build command to run. Default is `pnpm build`.                                         |

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -8,6 +8,9 @@ inputs:
     pnpm-version:
         description: "The version of pnpm to use"
         default: "9.0.6"
+    pnpm-cache:
+        description: "Cache strategy can be one of `read`, `write`, or `off`"
+        default: "write"
     npm-token:
         description: "NPM token for authenticating to the NPM registry"
         required: true
@@ -17,9 +20,6 @@ inputs:
     build:
         description: "Either false or the build command to run, default is `pnpm build`"
         default: "pnpm build"
-    pnpm-cache:
-        description: "Cache strategy can be one of `read`, `write`, or `off`"
-        default: "write"
 
 runs:
     using: "composite"

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -17,6 +17,9 @@ inputs:
     build:
         description: "Either false or the build command to run, default is `pnpm build`"
         default: "pnpm build"
+    pnpm-cache:
+        description: "Cache strategy can be one of `read`, `write`, or `off`"
+        default: "write"
 
 runs:
     using: "composite"
@@ -39,7 +42,18 @@ runs:
           run: |
               echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
+        - uses: actions/cache/restore@v4
+          if: ${{ inputs.pnpm-cache == 'read' }}
+          name: Initialize pnpm cache
+          with:
+              path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+              key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/package.json') }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+              restore-keys: |
+                  ${{ runner.os }}-pnpm-store-${{ hashFiles('**/package.json') }}-
+                  ${{ runner.os }}-pnpm-store-
+
         - uses: actions/cache@v4
+          if: ${{ inputs.pnpm-cache == 'write' }}
           name: Initialize pnpm cache
           with:
               path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}


### PR DESCRIPTION
This allows us to selectively use the pnpm cache store only for restore purposes, speeding up the jobs in the general case by centralizing the cache writes to a single job. 