### PR TITLE
Fix `build` step name

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -71,7 +71,7 @@ runs:
           shell: bash
           run: ${{ inputs.install }}
 
-        - name: Install dependencies
+        - name: Build
           if: ${{ inputs.build != 'false' }}
           shell: bash
           run: ${{ inputs.build }}


### PR DESCRIPTION
This fixes a mistake in the setup action, correcting the build step's name.