### PR TITLE
Add AI Translation PR reusable action and documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "cSpell.words": ["technance"]
+    "cSpell.words": [
+        "technance",
+        "Worphling"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -27,4 +27,7 @@ This repository contains reusable **composite GitHub Actions** maintained by Tec
 - [E2E Test Runner](e2e-test-runner/README.md)
   Full Playwright E2E test pipeline: installs deps, caches browsers, runs tests, uploads reports, and updates GitHub Check Runs. Replaces long multi-step workflows with one action. This E2E action relies on the external **Relay** service [^1].
 
+- [AI Translation PR](ai-translation-pr/README.md)
+  Maintains a deterministic Worphling-powered AI translation PR for monorepos or root projects. Detects affected projects, runs Worphling checks, syncs generated translations, and opens or updates a dedicated PR back into the source branch.
+
 [^1]: These E2E actions integrate with the external **Relay** service, which waits for preview deployments to become ready and then triggers the E2E workflow. Relay implementation: https://github.com/technance-foundation/vercel-to-github-relay See [RELAY.md](https://github.com/technance-foundation/github-actions/blob/main/RELAY.md) for a full explanation.

--- a/ai-translation-pr/README.md
+++ b/ai-translation-pr/README.md
@@ -24,6 +24,58 @@ This is useful for:
 - Root-level projects using `project-roots: "."`
 - Teams that want AI-generated translation changes reviewed separately
 
+## ⚠️ Required repository settings
+
+> [!IMPORTANT]  
+> This action creates and updates branches and pull requests using `github.token`.
+> By default, GitHub may block this unless repository permissions are configured correctly.
+
+You must enable the following settings in your repository:
+
+### 1. Allow GitHub Actions to create and approve pull requests
+
+Go to:
+
+**Settings → Actions → General → Workflow permissions**
+
+- Set **Workflow permissions** to:
+    - ✅ **Read and write permissions**
+
+- Enable:
+    - ✅ **Allow GitHub Actions to create and approve pull requests**
+
+### 2. Ensure workflow permissions include PR access
+
+Your workflow must include:
+
+```yaml
+permissions:
+    contents: write
+    pull-requests: write
+    issues: write
+```
+
+Without these permissions, the action will fail when trying to:
+
+- push the automation branch
+- create or update the translation PR
+- comment or close stale PRs
+
+### 3. (Optional) Branch protection rules
+
+If your repository uses branch protection:
+
+- Ensure the automation branch (e.g. `worphling/*`) is **not blocked**
+- Or allow GitHub Actions to bypass restrictions where appropriate
+
+---
+
+If these settings are not configured, the action may fail with errors like:
+
+- `Resource not accessible by integration`
+- `Permission denied to create pull request`
+- `Failed to push to branch`
+
 ## Inputs
 
 | Name                        | Required | Description                                                                           |

--- a/ai-translation-pr/README.md
+++ b/ai-translation-pr/README.md
@@ -1,0 +1,170 @@
+# AI Translation PR
+
+Reusable composite GitHub Action that maintains a deterministic AI translation PR powered by Worphling.
+
+It is designed for repositories where translation files should be generated automatically whenever a source pull request changes.
+
+This action:
+
+- Detects affected Worphling-enabled projects
+- Runs `worphling check`
+- Creates or updates a dedicated automation branch
+- Runs `worphling sync`
+- Opens or updates a PR back into the source branch
+- Writes a readable pre-sync and post-sync summary into the PR body
+- Cleans up stale PRs and branches when no translation work is needed
+
+## When to use this
+
+Use this action when you want generated translation updates to live in a separate PR instead of modifying the source PR branch directly.
+
+This is useful for:
+
+- Monorepos with multiple Worphling-enabled apps or packages
+- Root-level projects using `project-roots: "."`
+- Teams that want AI-generated translation changes reviewed separately
+
+## Inputs
+
+| Name                        | Required | Description                                                                           |
+| --------------------------- | -------- | ------------------------------------------------------------------------------------- |
+| `github-token`              | Yes      | GitHub token used for branch and PR operations                                        |
+| `npm-token`                 | No       | NPM token used for private dependency installation                                    |
+| `openai-api-key`            | Yes      | OpenAI API key used by Worphling                                                      |
+| `pr-number`                 | Yes      | Source pull request number                                                            |
+| `source-branch`             | Yes      | Source pull request head branch                                                       |
+| `source-sha`                | Yes      | Source pull request head SHA                                                          |
+| `automation-branch`         | Yes      | Branch used for generated AI translation changes                                      |
+| `labels`                    | No       | Multiline labels applied to the AI translation PR                                     |
+| `node-version`              | No       | Node.js version                                                                       |
+| `pnpm-version`              | No       | pnpm version                                                                          |
+| `install-command`           | No       | Install command passed to the shared setup action                                     |
+| `build-command`             | No       | Build command passed to the shared setup action, or `false`                           |
+| `working-directory`         | No       | Working directory passed to the shared setup action                                   |
+| `project-roots`             | No       | Multiline list of Worphling project roots. Supports `.` and shell globs like `apps/*` |
+| `artifact-root`             | No       | Directory where Worphling reports are written                                         |
+| `global-invalidation-paths` | No       | Repo-level paths that invalidate all Worphling projects                               |
+| `pr-title-template`         | No       | PR title template. Use `__PR_NUMBER__` as the placeholder                             |
+| `pr-close-comment-template` | No       | Close comment template. Use `__PR_NUMBER__` as the placeholder                        |
+
+## Outputs
+
+| Name                     | Description                                                            |
+| ------------------------ | ---------------------------------------------------------------------- |
+| `affected-count`         | Number of affected Worphling-enabled projects                          |
+| `affected-projects-json` | JSON array of affected project keys                                    |
+| `changed-count`          | Number of projects that actually require generated translation changes |
+| `changed-projects-json`  | JSON array of changed project keys                                     |
+| `any-changes`            | Whether any project required generated translation changes             |
+
+## Placeholder format
+
+For user-configurable text templates, use:
+
+```txt
+__PR_NUMBER__
+```
+
+Example:
+
+```yaml
+pr-title-template: "Update AI translations for #__PR_NUMBER__"
+pr-close-comment-template: "Closing automatically because PR #__PR_NUMBER__ no longer requires generated AI translation updates."
+```
+
+## Monorepo example
+
+```yaml
+name: AI Translation PR
+
+on:
+    pull_request:
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - ready_for_review
+        paths:
+            - "apps/**"
+            - "apps/**/locales/**"
+            - "apps/**/worphling.config.*"
+            - "apps/**/translation-context.md"
+            - "package.json"
+            - "pnpm-lock.yaml"
+
+concurrency:
+    group: ai-translation-pr-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+permissions:
+    contents: write
+    pull-requests: write
+    issues: write
+
+jobs:
+    ai-translation-pr:
+        if: >
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            !startsWith(github.event.pull_request.head.ref, 'worphling/')
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout source PR head
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  fetch-depth: 0
+                  persist-credentials: true
+
+            - name: Maintain AI translation PR
+              uses: technance-foundation/github-actions/ai-translation-pr@main
+              with:
+                  github-token: ${{ github.token }}
+                  npm-token: ${{ secrets.NPM_TOKEN }}
+                  openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+                  pr-number: ${{ github.event.pull_request.number }}
+                  source-branch: ${{ github.event.pull_request.head.ref }}
+                  source-sha: ${{ github.event.pull_request.head.sha }}
+                  automation-branch: worphling/pr-${{ github.event.pull_request.number }}
+                  project-roots: |
+                      apps/*
+                  artifact-root: ".github-artifacts/worphling"
+                  global-invalidation-paths: |
+                      package.json
+                      pnpm-lock.yaml
+                  pr-title-template: "Update AI translations for #__PR_NUMBER__"
+                  pr-close-comment-template: "Closing automatically because PR #__PR_NUMBER__ no longer requires generated AI translation updates."
+                  labels: |
+                      automated
+                      translations
+                      worphling
+```
+
+## Root project example
+
+```yaml
+- name: Maintain AI translation PR
+  uses: technance-foundation/github-actions/ai-translation-pr@main
+  with:
+      github-token: ${{ github.token }}
+      npm-token: ${{ secrets.NPM_TOKEN }}
+      openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+      pr-number: ${{ github.event.pull_request.number }}
+      source-branch: ${{ github.event.pull_request.head.ref }}
+      source-sha: ${{ github.event.pull_request.head.sha }}
+      automation-branch: worphling/pr-${{ github.event.pull_request.number }}
+      project-roots: |
+          .
+      artifact-root: ".github-artifacts/worphling"
+      global-invalidation-paths: |
+          package.json
+          pnpm-lock.yaml
+```
+
+## Notes
+
+- The action expects the caller workflow to checkout the repository before using it.
+- `project-roots` can mix globs and explicit paths.
+- If a global invalidation path changes, all Worphling-enabled projects are included.
+- The generated PR body contains both pre-sync and post-sync summaries for easier review.

--- a/ai-translation-pr/action.yml
+++ b/ai-translation-pr/action.yml
@@ -1,0 +1,223 @@
+name: AI Translation PR
+description: Maintain a deterministic Worphling-powered AI translation branch and PR for monorepos or root projects.
+
+inputs:
+    github-token:
+        description: GitHub token used for PR and branch operations
+        required: true
+
+    npm-token:
+        description: NPM token used for dependency installation
+        required: false
+
+    openai-api-key:
+        description: OpenAI API key used by Worphling
+        required: true
+
+    pr-number:
+        description: Source pull request number
+        required: true
+
+    source-branch:
+        description: Source pull request head branch name
+        required: true
+
+    source-sha:
+        description: Source pull request head SHA
+        required: true
+
+    automation-branch:
+        description: Automation branch name used for the generated AI translation PR
+        required: true
+
+    labels:
+        description: Multiline list of labels to apply to the AI translation PR
+        required: false
+        default: |
+            automated
+            translations
+            worphling
+
+    node-version:
+        description: Node.js version
+        required: false
+        default: "22"
+
+    pnpm-version:
+        description: pnpm version
+        required: false
+        default: "10.15.0"
+
+    install-command:
+        description: Install command passed to shared setup action
+        required: false
+        default: "pnpm install --no-frozen-lockfile"
+
+    build-command:
+        description: Build command passed to shared setup action, or false
+        required: false
+        default: "false"
+
+    working-directory:
+        description: Working directory passed to shared setup action
+        required: false
+        default: "."
+
+    project-roots:
+        description: |
+            Multiline list of Worphling project roots.
+            Supports "." and shell globs like "apps/*" or "packages/*".
+        required: false
+        default: |
+            apps/*
+
+    artifact-root:
+        description: Root directory for generated Worphling reports
+        required: false
+        default: ".github-artifacts/worphling"
+
+    global-invalidation-paths:
+        description: Multiline list of repo-level paths that invalidate all Worphling projects
+        required: false
+        default: |
+            package.json
+            pnpm-lock.yaml
+
+    pr-title-template:
+        description: |
+            AI translation PR title template.
+
+            Use __PR_NUMBER__ as the placeholder.
+
+            Example:
+            Update AI translations for #__PR_NUMBER__
+        required: false
+        default: "Update AI translations for #__PR_NUMBER__"
+
+    pr-close-comment-template:
+        description: |
+            AI translation PR close comment template.
+
+            Use __PR_NUMBER__ as the placeholder.
+
+            Example:
+            Closing automatically because PR #__PR_NUMBER__ no longer requires generated AI translation updates.
+        required: false
+        default: "Closing automatically because PR #__PR_NUMBER__ no longer requires generated AI translation updates."
+
+outputs:
+    affected-count:
+        description: Number of affected Worphling-enabled projects
+        value: ${{ steps.detect.outputs.affected_count }}
+
+    affected-projects-json:
+        description: JSON array of affected Worphling-enabled project keys
+        value: ${{ steps.detect.outputs.affected_projects_json }}
+
+    changed-count:
+        description: Number of projects that actually required generated translation changes
+        value: ${{ steps.checks.outputs.changed_count }}
+
+    changed-projects-json:
+        description: JSON array of project keys with real translation changes
+        value: ${{ steps.checks.outputs.changed_projects_json }}
+
+    any-changes:
+        description: Whether any project required generated translation changes
+        value: ${{ steps.checks.outputs.any_changes }}
+
+runs:
+    using: composite
+    steps:
+        - name: Make action scripts executable
+          shell: bash
+          run: chmod +x "$GITHUB_ACTION_PATH"/*.sh
+
+        - name: Detect affected Worphling projects
+          id: detect
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github-token }}
+              PR_NUMBER: ${{ inputs.pr-number }}
+              GITHUB_REPOSITORY: ${{ github.repository }}
+              PROJECT_ROOTS: ${{ inputs.project-roots }}
+              ARTIFACT_ROOT: ${{ inputs.artifact-root }}
+              GLOBAL_INVALIDATION_PATHS: ${{ inputs.global-invalidation-paths }}
+          run: "$GITHUB_ACTION_PATH/detect-affected-projects.sh"
+
+        - name: Cleanup stale AI translation PR and branch when no projects are affected
+          if: ${{ steps.detect.outputs.affected_count == '0' }}
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github-token }}
+              PR_NUMBER: ${{ inputs.pr-number }}
+              AUTOMATION_BRANCH: ${{ inputs.automation-branch }}
+              GITHUB_REPOSITORY: ${{ github.repository }}
+              AI_TRANSLATION_PR_CLOSE_COMMENT_TEMPLATE: ${{ inputs.pr-close-comment-template }}
+          run: "$GITHUB_ACTION_PATH/cleanup-ai-translation-pr.sh"
+
+        - name: Setup repository
+          if: ${{ steps.detect.outputs.affected_count != '0' }}
+          uses: technance-foundation/github-actions/setup@v1
+          with:
+              node-version: ${{ inputs.node-version }}
+              pnpm-version: ${{ inputs.pnpm-version }}
+              npm-token: ${{ inputs.npm-token }}
+              pnpm-cache: "write"
+              install: ${{ inputs.install-command }}
+              build: ${{ inputs.build-command }}
+              working-directory: ${{ inputs.working-directory }}
+
+        - name: Run Worphling checks
+          if: ${{ steps.detect.outputs.affected_count != '0' }}
+          id: checks
+          shell: bash
+          env:
+              GITHUB_OUTPUT: ${{ github.output }}
+              PR_NUMBER: ${{ inputs.pr-number }}
+              SOURCE_BRANCH: ${{ inputs.source-branch }}
+              AUTOMATION_BRANCH: ${{ inputs.automation-branch }}
+              AFFECTED_PROJECTS_JSON: ${{ steps.detect.outputs.affected_projects_json }}
+              PROJECT_ROOTS: ${{ inputs.project-roots }}
+              ARTIFACT_ROOT: ${{ inputs.artifact-root }}
+              OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+          run: "$GITHUB_ACTION_PATH/run-checks.sh"
+
+        - name: Create or update AI translation branch and PR
+          if: ${{ steps.detect.outputs.affected_count != '0' && steps.checks.outputs.any_changes == 'true' }}
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github-token }}
+              OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+              PR_NUMBER: ${{ inputs.pr-number }}
+              SOURCE_BRANCH: ${{ inputs.source-branch }}
+              SOURCE_SHA: ${{ inputs.source-sha }}
+              AUTOMATION_BRANCH: ${{ inputs.automation-branch }}
+              GITHUB_REPOSITORY: ${{ github.repository }}
+              CHANGED_PROJECTS_JSON: ${{ steps.checks.outputs.changed_projects_json }}
+              PR_BODY_FILE: ${{ steps.checks.outputs.pr_body_file }}
+              PROJECT_ROOTS: ${{ inputs.project-roots }}
+              ARTIFACT_ROOT: ${{ inputs.artifact-root }}
+              AI_TRANSLATION_PR_LABELS: ${{ inputs.labels }}
+              AI_TRANSLATION_PR_TITLE_TEMPLATE: ${{ inputs.pr-title-template }}
+          run: "$GITHUB_ACTION_PATH/sync-and-publish-ai-translation-pr.sh"
+
+        - name: Cleanup stale AI translation PR and branch when no translation changes remain
+          if: ${{ steps.detect.outputs.affected_count != '0' && steps.checks.outputs.any_changes == 'false' }}
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github-token }}
+              PR_NUMBER: ${{ inputs.pr-number }}
+              AUTOMATION_BRANCH: ${{ inputs.automation-branch }}
+              GITHUB_REPOSITORY: ${{ github.repository }}
+              AI_TRANSLATION_PR_CLOSE_COMMENT_TEMPLATE: ${{ inputs.pr-close-comment-template }}
+          run: "$GITHUB_ACTION_PATH/cleanup-ai-translation-pr.sh"
+
+        - name: Upload Worphling reports
+          if: ${{ always() && steps.detect.outputs.affected_count != '0' }}
+          uses: actions/upload-artifact@v4
+          with:
+              name: worphling-ai-translation-pr-${{ inputs.pr-number }}-reports
+              path: ${{ inputs.artifact-root }}/
+              retention-days: 30
+              if-no-files-found: ignore

--- a/ai-translation-pr/action.yml
+++ b/ai-translation-pr/action.yml
@@ -173,6 +173,7 @@ runs:
           id: checks
           shell: bash
           env:
+              GH_TOKEN: ${{ inputs.github-token }}
               PR_NUMBER: ${{ inputs.pr-number }}
               SOURCE_BRANCH: ${{ inputs.source-branch }}
               AUTOMATION_BRANCH: ${{ inputs.automation-branch }}

--- a/ai-translation-pr/action.yml
+++ b/ai-translation-pr/action.yml
@@ -116,15 +116,15 @@ outputs:
 
     changed-count:
         description: Number of projects that actually required generated translation changes
-        value: ${{ steps.checks.outputs.changed_count }}
+        value: ${{ steps.checks.outputs.changed_count || '0' }}
 
     changed-projects-json:
         description: JSON array of project keys with real translation changes
-        value: ${{ steps.checks.outputs.changed_projects_json }}
+        value: ${{ steps.checks.outputs.changed_projects_json || '[]' }}
 
     any-changes:
         description: Whether any project required generated translation changes
-        value: ${{ steps.checks.outputs.any_changes }}
+        value: ${{ steps.checks.outputs.any_changes || 'false' }}
 
 runs:
     using: composite

--- a/ai-translation-pr/action.yml
+++ b/ai-translation-pr/action.yml
@@ -173,7 +173,6 @@ runs:
           id: checks
           shell: bash
           env:
-              GITHUB_OUTPUT: ${{ github.output }}
               PR_NUMBER: ${{ inputs.pr-number }}
               SOURCE_BRANCH: ${{ inputs.source-branch }}
               AUTOMATION_BRANCH: ${{ inputs.automation-branch }}

--- a/ai-translation-pr/cleanup-ai-translation-pr.sh
+++ b/ai-translation-pr/cleanup-ai-translation-pr.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${AUTOMATION_BRANCH:?AUTOMATION_BRANCH is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+render_template() {
+  local template="$1"
+  local pr_number="$2"
+
+  template="${template//__PR_NUMBER__/$pr_number}"
+
+  printf '%s\n' "$template"
+}
+
+comment_template="${AI_TRANSLATION_PR_CLOSE_COMMENT_TEMPLATE:-Closing automatically because PR #__PR_NUMBER__ no longer requires generated AI translation updates.}"
+comment="$(render_template "$comment_template" "$PR_NUMBER")"
+
+open_pr_number="$({ gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "${AUTOMATION_BRANCH}" --json number --jq '.[0].number // empty'; } || true)"
+
+if [ -n "$open_pr_number" ]; then
+  gh pr close "$open_pr_number" \
+    --repo "$GITHUB_REPOSITORY" \
+    --comment "$comment" \
+    --delete-branch=false
+fi
+
+git push origin --delete "$AUTOMATION_BRANCH" >/dev/null 2>&1 || true

--- a/ai-translation-pr/detect-affected-projects.sh
+++ b/ai-translation-pr/detect-affected-projects.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required but was not found on PATH." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but was not found on PATH." >&2
+  exit 1
+fi
+
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+PROJECT_ROOTS_RAW="${PROJECT_ROOTS:-apps/*}"
+REPORT_ROOT="${ARTIFACT_ROOT:-.github-artifacts/worphling}"
+GLOBAL_INVALIDATION_PATHS_RAW="${GLOBAL_INVALIDATION_PATHS:-package.json
+pnpm-lock.yaml}"
+
+mkdir -p "$REPORT_ROOT"
+
+find_project_config() {
+  local project_dir="$1"
+  find "$project_dir" -maxdepth 1 -type f \
+    \( -name 'worphling.config.js' -o -name 'worphling.config.mjs' -o -name 'worphling.config.cjs' -o -name 'worphling.config.ts' \) \
+    | sort \
+    | head -n 1
+}
+
+normalize_path() {
+  local value="$1"
+
+  if [ "$value" = "." ]; then
+    printf '.\n'
+    return
+  fi
+
+  value="${value%/}"
+  printf '%s\n' "$value"
+}
+
+project_key_for_path() {
+  local project_path="$1"
+
+  if [ "$project_path" = "." ]; then
+    printf 'root\n'
+    return
+  fi
+
+  local base
+  base="$(basename "$project_path")"
+
+  if [ -n "$base" ] && [ "$base" != "." ] && [ "$base" != "/" ]; then
+    printf '%s\n' "$base"
+    return
+  fi
+
+  printf '%s\n' "$project_path" | sed 's#[/ ]#-#g'
+}
+
+expand_project_roots() {
+  local line
+  local pattern
+  local matched
+
+  while IFS= read -r line; do
+    pattern="$(printf '%s' "$line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ -z "$pattern" ] && continue
+
+    if [ "$pattern" = "." ]; then
+      printf '.\n'
+      continue
+    fi
+
+    matched="false"
+    while IFS= read -r path; do
+      [ -z "$path" ] && continue
+      matched="true"
+      normalize_path "$path"
+    done < <(compgen -G "$pattern" || true)
+
+    if [ "$matched" = "false" ] && [ -d "$pattern" ]; then
+      normalize_path "$pattern"
+    fi
+  done <<< "$PROJECT_ROOTS_RAW"
+}
+
+is_global_invalidation_path() {
+  local candidate="$1"
+  local path
+
+  while IFS= read -r path; do
+    path="$(printf '%s' "$path" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ -z "$path" ] && continue
+
+    if [ "$candidate" = "$path" ]; then
+      return 0
+    fi
+  done <<< "$GLOBAL_INVALIDATION_PATHS_RAW"
+
+  return 1
+}
+
+file_belongs_to_project() {
+  local file="$1"
+  local project_path="$2"
+
+  if [ "$project_path" = "." ]; then
+    return 0
+  fi
+
+  case "$file" in
+    "$project_path"/*) return 0 ;;
+    "$project_path") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+declare -A project_path_by_key=()
+
+while IFS= read -r project_path; do
+  [ -z "$project_path" ] && continue
+  [ -d "$project_path" ] || continue
+
+  if [ -n "$(find_project_config "$project_path")" ]; then
+    project_key="$(project_key_for_path "$project_path")"
+    project_path_by_key["$project_key"]="$project_path"
+  fi
+done < <(expand_project_roots | sort -u)
+
+mapfile -t changed_files < <(
+  gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename'
+)
+
+echo "Changed files for PR #${PR_NUMBER}:"
+printf ' - %s\n' "${changed_files[@]:-}"
+
+declare -A affected_map=()
+global_invalidation="false"
+
+for file in "${changed_files[@]:-}"; do
+  if is_global_invalidation_path "$file"; then
+    global_invalidation="true"
+  fi
+done
+
+if [ "$global_invalidation" = "true" ]; then
+  echo "Global dependency/config file changed. Expanding to all Worphling-enabled projects."
+  for project_key in "${!project_path_by_key[@]}"; do
+    affected_map["$project_key"]=1
+  done
+else
+  for file in "${changed_files[@]:-}"; do
+    for project_key in "${!project_path_by_key[@]}"; do
+      project_path="${project_path_by_key[$project_key]}"
+      if file_belongs_to_project "$file" "$project_path"; then
+        affected_map["$project_key"]=1
+      fi
+    done
+  done
+fi
+
+affected_keys=()
+
+for project_key in "${!affected_map[@]}"; do
+  affected_keys+=("$project_key")
+done
+
+if [ "${#affected_keys[@]}" -gt 0 ]; then
+  IFS=$'\n' affected_keys=($(printf '%s\n' "${affected_keys[@]}" | sort -u))
+fi
+
+printf '%s\n' "${affected_keys[@]:-}" > "${REPORT_ROOT}/affected-projects.txt"
+
+affected_count="${#affected_keys[@]}"
+
+if [ "${#affected_keys[@]}" -gt 0 ]; then
+  affected_json="$(jq -cn '$ARGS.positional' --args "${affected_keys[@]}")"
+else
+  affected_json='[]'
+fi
+
+{
+  echo "affected_count=${affected_count}"
+  echo "affected_projects_json=${affected_json}"
+} >> "$GITHUB_OUTPUT"
+
+echo "Affected Worphling projects (${affected_count}):"
+printf ' - %s\n' "${affected_keys[@]:-}"

--- a/ai-translation-pr/detect-affected-projects.sh
+++ b/ai-translation-pr/detect-affected-projects.sh
@@ -49,15 +49,8 @@ project_key_for_path() {
     return
   fi
 
-  local base
-  base="$(basename "$project_path")"
-
-  if [ -n "$base" ] && [ "$base" != "." ] && [ "$base" != "/" ]; then
-    printf '%s\n' "$base"
-    return
-  fi
-
-  printf '%s\n' "$project_path" | sed 's#[/ ]#-#g'
+  project_path="${project_path%/}"
+  printf '%s\n' "$project_path" | sed 's#[/. ]#-#g'
 }
 
 expand_project_roots() {

--- a/ai-translation-pr/run-checks.sh
+++ b/ai-translation-pr/run-checks.sh
@@ -45,15 +45,8 @@ project_key_for_path() {
     return
   fi
 
-  local base
-  base="$(basename "$project_path")"
-
-  if [ -n "$base" ] && [ "$base" != "." ] && [ "$base" != "/" ]; then
-    printf '%s\n' "$base"
-    return
-  fi
-
-  printf '%s\n' "$project_path" | sed 's#[/ ]#-#g'
+  project_path="${project_path%/}"
+  printf '%s\n' "$project_path" | sed 's#[/. ]#-#g'
 }
 
 project_label_for_key() {

--- a/ai-translation-pr/run-checks.sh
+++ b/ai-translation-pr/run-checks.sh
@@ -17,6 +17,8 @@ REPORT_ROOT="${ARTIFACT_ROOT:-.github-artifacts/worphling}"
 
 mkdir -p "$REPORT_ROOT"
 
+repo_root="$(git rev-parse --show-toplevel)"
+
 find_project_config() {
   local project_dir="$1"
   find "$project_dir" -maxdepth 1 -type f \
@@ -146,7 +148,6 @@ pr_body_file="${REPORT_ROOT}/ai-translation-pr-body.md"
   echo "This PR is automatically maintained by the AI translation workflow."
   echo
   echo "It contains generated translation updates for source PR #${PR_NUMBER}."
-  echo
   echo "## Overview"
   echo
   echo "- **Source PR**: #${PR_NUMBER}"
@@ -180,6 +181,7 @@ for project_key in "${project_keys[@]}"; do
   mkdir -p "$project_report_dir"
 
   check_report="${project_report_dir}/check-report.json"
+  check_report_abs="${repo_root}/${check_report}"
   project_label="$(project_label_for_key "$project_key")"
 
   echo "Running worphling check for ${project_label}"
@@ -189,14 +191,17 @@ for project_key in "${project_keys[@]}"; do
     cd "$project_dir"
     OPENAI_API_KEY="${OPENAI_API_KEY:-}" pnpm exec worphling check \
       --config "$config_name" \
-      --report-file "../../${check_report}"
+      --report-file "$check_report_abs"
   )
   exit_code=$?
   set -e
 
   if [ ! -s "$check_report" ]; then
     echo "worphling check did not produce a readable report for ${project_label} (exit code ${exit_code})" >&2
-    exit "$exit_code"
+    if [ "$exit_code" -ne 0 ]; then
+      exit "$exit_code"
+    fi
+    exit 1
   fi
 
   if ! jq -e '.summary.hasChanges != null' "$check_report" >/dev/null 2>&1; then

--- a/ai-translation-pr/run-checks.sh
+++ b/ai-translation-pr/run-checks.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but was not found on PATH." >&2
+  exit 1
+fi
+
+: "${AFFECTED_PROJECTS_JSON:?AFFECTED_PROJECTS_JSON is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${SOURCE_BRANCH:?SOURCE_BRANCH is required}"
+: "${AUTOMATION_BRANCH:?AUTOMATION_BRANCH is required}"
+
+PROJECT_ROOTS_RAW="${PROJECT_ROOTS:-apps/*}"
+REPORT_ROOT="${ARTIFACT_ROOT:-.github-artifacts/worphling}"
+
+mkdir -p "$REPORT_ROOT"
+
+find_project_config() {
+  local project_dir="$1"
+  find "$project_dir" -maxdepth 1 -type f \
+    \( -name 'worphling.config.js' -o -name 'worphling.config.mjs' -o -name 'worphling.config.cjs' -o -name 'worphling.config.ts' \) \
+    | sort \
+    | head -n 1
+}
+
+normalize_path() {
+  local value="$1"
+
+  if [ "$value" = "." ]; then
+    printf '.\n'
+    return
+  fi
+
+  value="${value%/}"
+  printf '%s\n' "$value"
+}
+
+project_key_for_path() {
+  local project_path="$1"
+
+  if [ "$project_path" = "." ]; then
+    printf 'root\n'
+    return
+  fi
+
+  local base
+  base="$(basename "$project_path")"
+
+  if [ -n "$base" ] && [ "$base" != "." ] && [ "$base" != "/" ]; then
+    printf '%s\n' "$base"
+    return
+  fi
+
+  printf '%s\n' "$project_path" | sed 's#[/ ]#-#g'
+}
+
+project_label_for_key() {
+  local project_key="$1"
+
+  if [ "$project_key" = "root" ]; then
+    printf 'root project\n'
+    return
+  fi
+
+  printf '%s\n' "$project_key"
+}
+
+expand_project_roots() {
+  local line
+  local pattern
+  local matched
+
+  while IFS= read -r line; do
+    pattern="$(printf '%s' "$line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ -z "$pattern" ] && continue
+
+    if [ "$pattern" = "." ]; then
+      printf '.\n'
+      continue
+    fi
+
+    matched="false"
+    while IFS= read -r path; do
+      [ -z "$path" ] && continue
+      matched="true"
+      normalize_path "$path"
+    done < <(compgen -G "$pattern" || true)
+
+    if [ "$matched" = "false" ] && [ -d "$pattern" ]; then
+      normalize_path "$pattern"
+    fi
+  done <<< "$PROJECT_ROOTS_RAW"
+}
+
+declare -A project_path_by_key=()
+
+while IFS= read -r project_path; do
+  [ -z "$project_path" ] && continue
+  [ -d "$project_path" ] || continue
+
+  if [ -n "$(find_project_config "$project_path")" ]; then
+    project_key="$(project_key_for_path "$project_path")"
+    project_path_by_key["$project_key"]="$project_path"
+  fi
+done < <(expand_project_roots | sort -u)
+
+json_number() {
+  local file="$1"
+  local jq_expr="$2"
+  jq -r "$jq_expr // 0" "$file" 2>/dev/null || echo "0"
+}
+
+extract_missing() {
+  local file="$1"
+  json_number "$file" '
+    .summary.missingCount
+    // .summary.missing
+    // .counts.missing
+    // .totals.missing
+  '
+}
+
+extract_extra() {
+  local file="$1"
+  json_number "$file" '
+    .summary.extraCount
+    // .summary.extra
+    // .counts.extra
+    // .totals.extra
+  '
+}
+
+extract_modified() {
+  local file="$1"
+  json_number "$file" '
+    .summary.modifiedCount
+    // .summary.modified
+    // .counts.modified
+    // .totals.modified
+  '
+}
+
+mapfile -t project_keys < <(jq -r '.[]' <<<"$AFFECTED_PROJECTS_JSON")
+
+changed_project_keys=()
+pr_body_file="${REPORT_ROOT}/ai-translation-pr-body.md"
+
+{
+  echo "# 🤖 AI translation PR"
+  echo
+  echo "This PR is automatically maintained by the AI translation workflow."
+  echo
+  echo "It contains generated translation updates for source PR #${PR_NUMBER}."
+  echo
+  echo "## Overview"
+  echo
+  echo "- **Source PR**: #${PR_NUMBER}"
+  echo "- **Source branch**: \`${SOURCE_BRANCH}\`"
+  echo "- **Automation branch**: \`${AUTOMATION_BRANCH}\`"
+  echo
+  echo "> [!IMPORTANT]"
+  echo "> Merge this AI translation PR into the source branch before the source PR is merged to \`main\`."
+  echo
+  echo "## 📦 Projects selected for review"
+  echo
+} > "$pr_body_file"
+
+for project_key in "${project_keys[@]}"; do
+  project_dir="${project_path_by_key[$project_key]:-}"
+
+  if [ -z "$project_dir" ]; then
+    echo "No project directory found for key ${project_key}, skipping."
+    continue
+  fi
+
+  config_file="$(find_project_config "$project_dir")"
+
+  if [ -z "$config_file" ]; then
+    echo "No Worphling config found for ${project_dir}, skipping."
+    continue
+  fi
+
+  config_name="$(basename "$config_file")"
+  project_report_dir="${REPORT_ROOT}/${project_key}"
+  mkdir -p "$project_report_dir"
+
+  check_report="${project_report_dir}/check-report.json"
+  project_label="$(project_label_for_key "$project_key")"
+
+  echo "Running worphling check for ${project_label}"
+
+  set +e
+  (
+    cd "$project_dir"
+    OPENAI_API_KEY="${OPENAI_API_KEY:-}" pnpm exec worphling check \
+      --config "$config_name" \
+      --report-file "../../${check_report}"
+  )
+  exit_code=$?
+  set -e
+
+  if [ ! -s "$check_report" ]; then
+    echo "worphling check did not produce a readable report for ${project_label} (exit code ${exit_code})" >&2
+    exit "$exit_code"
+  fi
+
+  if ! jq -e '.summary.hasChanges != null' "$check_report" >/dev/null 2>&1; then
+    echo "worphling check report for ${project_label} is missing summary.hasChanges" >&2
+    cat "$check_report" >&2 || true
+    exit 1
+  fi
+
+  echo "worphling check exit code for ${project_label}: ${exit_code}"
+
+  has_changes="$(jq -r '.summary.hasChanges // false' "$check_report")"
+
+  if [ "$has_changes" = "true" ]; then
+    changed_project_keys+=("$project_key")
+    echo "- ✅ \`${project_label}\`" >> "$pr_body_file"
+  else
+    echo "- ℹ️ \`${project_label}\` -- already up to date" >> "$pr_body_file"
+  fi
+done
+
+if [ "${#changed_project_keys[@]}" -gt 0 ]; then
+  {
+    echo
+    echo "## 🔎 Pre-sync summary"
+    echo
+    echo "The following projects still need generated translation updates before sync runs:"
+    echo
+    echo
+    echo "| Project | Missing | Extra | Modified |"
+    echo "| --- | ---: | ---: | ---: |"
+  } >> "$pr_body_file"
+
+  for project_key in "${changed_project_keys[@]}"; do
+    check_report="${REPORT_ROOT}/${project_key}/check-report.json"
+    project_label="$(project_label_for_key "$project_key")"
+    missing_count="$(extract_missing "$check_report")"
+    extra_count="$(extract_extra "$check_report")"
+    modified_count="$(extract_modified "$check_report")"
+
+    echo "| \`${project_label}\` | ${missing_count} | ${extra_count} | ${modified_count} |" >> "$pr_body_file"
+  done
+
+  {
+    echo
+    echo "## ✨ Post-sync summary"
+    echo
+    echo "_This section will be filled automatically after the sync step completes._"
+  } >> "$pr_body_file"
+else
+  {
+    echo
+    echo "## ✅ Pre-sync summary"
+    echo
+    echo "All reviewed projects are already up to date. No generated translation changes are needed."
+  } >> "$pr_body_file"
+fi
+
+changed_count="${#changed_project_keys[@]}"
+
+if [ "${#changed_project_keys[@]}" -gt 0 ]; then
+  changed_json="$(jq -cn '$ARGS.positional' --args "${changed_project_keys[@]}")"
+else
+  changed_json='[]'
+fi
+
+{
+  echo "changed_projects_json=${changed_json}"
+  echo "changed_count=${changed_count}"
+  echo "any_changes=$([ "$changed_count" -gt 0 ] && echo true || echo false)"
+  echo "pr_body_file=${pr_body_file}"
+} >> "$GITHUB_OUTPUT"
+
+echo "Projects with Worphling changes (${changed_count}):"
+for project_key in "${changed_project_keys[@]:-}"; do
+  project_label="$(project_label_for_key "$project_key")"
+  printf ' - %s\n' "$project_label"
+done

--- a/ai-translation-pr/sync-and-publish-ai-translation-pr.sh
+++ b/ai-translation-pr/sync-and-publish-ai-translation-pr.sh
@@ -65,15 +65,8 @@ project_key_for_path() {
     return
   fi
 
-  local base
-  base="$(basename "$project_path")"
-
-  if [ -n "$base" ] && [ "$base" != "." ] && [ "$base" != "/" ]; then
-    printf '%s\n' "$base"
-    return
-  fi
-
-  printf '%s\n' "$project_path" | sed 's#[/ ]#-#g'
+  project_path="${project_path%/}"
+  printf '%s\n' "$project_path" | sed 's#[/. ]#-#g'
 }
 
 project_label_for_key() {

--- a/ai-translation-pr/sync-and-publish-ai-translation-pr.sh
+++ b/ai-translation-pr/sync-and-publish-ai-translation-pr.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required but was not found on PATH." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but was not found on PATH." >&2
+  exit 1
+fi
+
+: "${CHANGED_PROJECTS_JSON:?CHANGED_PROJECTS_JSON is required}"
+: "${PR_BODY_FILE:?PR_BODY_FILE is required}"
+: "${OPENAI_API_KEY:?OPENAI_API_KEY is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${SOURCE_BRANCH:?SOURCE_BRANCH is required}"
+: "${SOURCE_SHA:?SOURCE_SHA is required}"
+: "${AUTOMATION_BRANCH:?AUTOMATION_BRANCH is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+PROJECT_ROOTS_RAW="${PROJECT_ROOTS:-apps/*}"
+REPORT_ROOT="${ARTIFACT_ROOT:-.github-artifacts/worphling}"
+PR_TITLE_TEMPLATE="${AI_TRANSLATION_PR_TITLE_TEMPLATE:-Update AI translations for #__PR_NUMBER__}"
+
+mkdir -p "$REPORT_ROOT"
+
+render_template() {
+  local template="$1"
+  local pr_number="$2"
+
+  template="${template//__PR_NUMBER__/$pr_number}"
+
+  printf '%s\n' "$template"
+}
+
+pr_title="$(render_template "$PR_TITLE_TEMPLATE" "$PR_NUMBER")"
+
+find_project_config() {
+  local project_dir="$1"
+  find "$project_dir" -maxdepth 1 -type f \
+    \( -name 'worphling.config.js' -o -name 'worphling.config.mjs' -o -name 'worphling.config.cjs' -o -name 'worphling.config.ts' \) \
+    | sort \
+    | head -n 1
+}
+
+normalize_path() {
+  local value="$1"
+
+  if [ "$value" = "." ]; then
+    printf '.\n'
+    return
+  fi
+
+  value="${value%/}"
+  printf '%s\n' "$value"
+}
+
+project_key_for_path() {
+  local project_path="$1"
+
+  if [ "$project_path" = "." ]; then
+    printf 'root\n'
+    return
+  fi
+
+  local base
+  base="$(basename "$project_path")"
+
+  if [ -n "$base" ] && [ "$base" != "." ] && [ "$base" != "/" ]; then
+    printf '%s\n' "$base"
+    return
+  fi
+
+  printf '%s\n' "$project_path" | sed 's#[/ ]#-#g'
+}
+
+project_label_for_key() {
+  local project_key="$1"
+
+  if [ "$project_key" = "root" ]; then
+    printf 'root project\n'
+    return
+  fi
+
+  printf '%s\n' "$project_key"
+}
+
+expand_project_roots() {
+  local line
+  local pattern
+  local matched
+
+  while IFS= read -r line; do
+    pattern="$(printf '%s' "$line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ -z "$pattern" ] && continue
+
+    if [ "$pattern" = "." ]; then
+      printf '.\n'
+      continue
+    fi
+
+    matched="false"
+    while IFS= read -r path; do
+      [ -z "$path" ] && continue
+      matched="true"
+      normalize_path "$path"
+    done < <(compgen -G "$pattern" || true)
+
+    if [ "$matched" = "false" ] && [ -d "$pattern" ]; then
+      normalize_path "$pattern"
+    fi
+  done <<< "$PROJECT_ROOTS_RAW"
+}
+
+declare -A project_path_by_key=()
+
+while IFS= read -r project_path; do
+  [ -z "$project_path" ] && continue
+  [ -d "$project_path" ] || continue
+
+  if [ -n "$(find_project_config "$project_path")" ]; then
+    project_key="$(project_key_for_path "$project_path")"
+    project_path_by_key["$project_key"]="$project_path"
+  fi
+done < <(expand_project_roots | sort -u)
+
+json_number() {
+  local file="$1"
+  local jq_expr="$2"
+  jq -r "$jq_expr // 0" "$file" 2>/dev/null || echo "0"
+}
+
+extract_missing() {
+  local file="$1"
+  json_number "$file" '
+    .summary.missingCount
+    // .summary.missing
+    // .counts.missing
+    // .totals.missing
+  '
+}
+
+extract_extra() {
+  local file="$1"
+  json_number "$file" '
+    .summary.extraCount
+    // .summary.extra
+    // .counts.extra
+    // .totals.extra
+  '
+}
+
+extract_modified() {
+  local file="$1"
+  json_number "$file" '
+    .summary.modifiedCount
+    // .summary.modified
+    // .counts.modified
+    // .totals.modified
+  '
+}
+
+count_staged_files_for_project() {
+  local project_dir="$1"
+  local count="0"
+
+  count="$(git diff --cached --name-only -- "$project_dir" | sed '/^[[:space:]]*$/d' | wc -l | tr -d '[:space:]')"
+
+  if [ -z "$count" ]; then
+    count="0"
+  fi
+
+  printf '%s\n' "$count"
+}
+
+apply_labels_to_pr() {
+  local pr_number="$1"
+
+  if [ -z "${AI_TRANSLATION_PR_LABELS:-}" ]; then
+    return 0
+  fi
+
+  while IFS= read -r label; do
+    label="$(printf '%s' "$label" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ -z "$label" ] && continue
+
+    gh pr edit "$pr_number" \
+      --repo "$GITHUB_REPOSITORY" \
+      --add-label "$label" || true
+  done <<< "$AI_TRANSLATION_PR_LABELS"
+}
+
+find_open_pr_number() {
+  gh pr list \
+    --repo "$GITHUB_REPOSITORY" \
+    --state open \
+    --head "$AUTOMATION_BRANCH" \
+    --json number \
+    --jq '.[0].number // empty'
+}
+
+find_closed_unmerged_pr_number() {
+  gh pr list \
+    --repo "$GITHUB_REPOSITORY" \
+    --state closed \
+    --head "$AUTOMATION_BRANCH" \
+    --json number,mergedAt \
+    --jq '.[] | select(.mergedAt == null) | .number' \
+    | head -n 1
+}
+
+replace_post_sync_section() {
+  local body_file="$1"
+  local replacement_file="$2"
+
+  local cleaned_file
+  cleaned_file="$(mktemp)"
+
+  awk '
+    BEGIN {
+      in_post_sync = 0
+    }
+    /^## ✨ Post-sync summary$/ {
+      if (!in_post_sync) {
+        in_post_sync = 1
+      }
+      next
+    }
+    in_post_sync && /^## / {
+      in_post_sync = 0
+      print
+      next
+    }
+    !in_post_sync {
+      print
+    }
+  ' "$body_file" > "$cleaned_file"
+
+  {
+    sed -e :a -e '/^[[:space:]]*$/{$d;N;ba' -e '}' "$cleaned_file"
+    echo
+    echo
+    cat "$replacement_file"
+    echo
+  } > "$body_file"
+}
+
+mapfile -t changed_project_keys < <(jq -r '.[]' <<<"$CHANGED_PROJECTS_JSON")
+
+if [ "${#changed_project_keys[@]}" -eq 0 ]; then
+  echo "No changed projects provided. Nothing to sync."
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+temp_pr_body="$(mktemp)"
+cp "$PR_BODY_FILE" "$temp_pr_body"
+
+echo "Rebuilding ${AUTOMATION_BRANCH} deterministically from ${SOURCE_SHA}"
+git checkout --force -B "$AUTOMATION_BRANCH" "$SOURCE_SHA"
+git clean -fd
+
+mkdir -p "$REPORT_ROOT"
+
+post_sync_summary_file="$(mktemp)"
+project_cards_file="$(mktemp)"
+
+{
+  echo "## ✨ Post-sync summary"
+  echo
+  echo "Generated translations were applied successfully."
+  echo
+  echo
+  echo "| Project | Result | Files changed | Remaining issues |"
+  echo "| --- | --- | ---: | --- |"
+} > "$post_sync_summary_file"
+
+for project_key in "${changed_project_keys[@]}"; do
+  project_dir="${project_path_by_key[$project_key]:-}"
+
+  if [ -z "$project_dir" ]; then
+    echo "No project directory found for key ${project_key}" >&2
+    exit 1
+  fi
+
+  config_file="$(find_project_config "$project_dir")"
+
+  if [ -z "$config_file" ]; then
+    echo "No Worphling config found for ${project_dir}" >&2
+    exit 1
+  fi
+
+  config_name="$(basename "$config_file")"
+  project_report_dir="${REPORT_ROOT}/${project_key}"
+  mkdir -p "$project_report_dir"
+
+  sync_report="${project_report_dir}/sync-report.json"
+  post_check_report="${project_report_dir}/post-check-report.json"
+  project_label="$(project_label_for_key "$project_key")"
+
+  echo "Running worphling sync for ${project_label}"
+  set +e
+  (
+    cd "$project_dir"
+    OPENAI_API_KEY="$OPENAI_API_KEY" pnpm exec worphling sync \
+      --write \
+      --config "$config_name" \
+      --report-file "../../${sync_report}"
+  )
+  sync_exit_code=$?
+  set -e
+
+  if [ ! -s "$sync_report" ]; then
+    echo "worphling sync did not produce a readable report for ${project_label} (exit code ${sync_exit_code})" >&2
+    exit "$sync_exit_code"
+  fi
+
+  echo "worphling sync exit code for ${project_label}: ${sync_exit_code}"
+
+  echo "Running post-sync CI check for ${project_label}"
+  set +e
+  (
+    cd "$project_dir"
+    OPENAI_API_KEY="$OPENAI_API_KEY" pnpm exec worphling check \
+      --ci \
+      --config "$config_name" \
+      --report-file "../../${post_check_report}"
+  )
+  exit_code=$?
+  set -e
+
+  if [ ! -s "$post_check_report" ]; then
+    echo "Post-sync worphling check did not produce a readable report for ${project_label} (exit code ${exit_code})" >&2
+    exit "$exit_code"
+  fi
+
+  if ! jq -e '.summary.hasChanges != null' "$post_check_report" >/dev/null 2>&1; then
+    echo "Post-sync report for ${project_label} is missing summary.hasChanges" >&2
+    cat "$post_check_report" >&2 || true
+    exit 1
+  fi
+
+  echo "Post-sync worphling check exit code for ${project_label}: ${exit_code}"
+
+  has_changes="$(jq -r '.summary.hasChanges // false' "$post_check_report")"
+  if [ "$has_changes" != "false" ]; then
+    echo "Post-sync CI verification still reports changes for ${project_label}" >&2
+    exit 1
+  fi
+
+  if [ -d "${project_dir}/locales" ]; then
+    git add --all -- "${project_dir}/locales"
+  fi
+
+  if [ -d "${project_dir}/.worphling" ]; then
+    git add --all -- "${project_dir}/.worphling"
+  fi
+
+  staged_files_count="$(count_staged_files_for_project "$project_dir")"
+  remaining_missing="$(extract_missing "$post_check_report")"
+  remaining_extra="$(extract_extra "$post_check_report")"
+  remaining_modified="$(extract_modified "$post_check_report")"
+
+  echo "| \`${project_label}\` | ✅ Synced | ${staged_files_count} | missing: ${remaining_missing}, extra: ${remaining_extra}, modified: ${remaining_modified} |" >> "$post_sync_summary_file"
+
+  {
+    echo
+    echo "<details>"
+    echo "<summary><strong>📌 ${project_label}</strong></summary>"
+    echo
+    echo "- **Result**: ✅ Synced successfully"
+    echo "- **Files changed**: ${staged_files_count}"
+    echo "- **Remaining missing**: ${remaining_missing}"
+    echo "- **Remaining extra**: ${remaining_extra}"
+    echo "- **Remaining modified**: ${remaining_modified}"
+    echo
+    echo "</details>"
+  } >> "$project_cards_file"
+done
+
+if git diff --cached --quiet; then
+  echo "Worphling reported changes but no generated files were staged." >&2
+  exit 1
+fi
+
+post_sync_combined_file="$(mktemp)"
+{
+  cat "$post_sync_summary_file"
+  cat "$project_cards_file"
+} > "$post_sync_combined_file"
+
+replace_post_sync_section "$temp_pr_body" "$post_sync_combined_file"
+
+git commit -m "Update AI translations for #${PR_NUMBER}"
+
+git push --force-with-lease origin "HEAD:refs/heads/${AUTOMATION_BRANCH}"
+
+open_pr_number="$(find_open_pr_number)"
+
+if [ -n "$open_pr_number" ]; then
+  gh pr edit "$open_pr_number" \
+    --repo "$GITHUB_REPOSITORY" \
+    --title "$pr_title" \
+    --body-file "$temp_pr_body"
+
+  apply_labels_to_pr "$open_pr_number"
+
+  echo "Updated existing AI translation PR #${open_pr_number}"
+  exit 0
+fi
+
+closed_unmerged_pr_number="$(find_closed_unmerged_pr_number)"
+
+if [ -n "$closed_unmerged_pr_number" ]; then
+  gh pr reopen "$closed_unmerged_pr_number" --repo "$GITHUB_REPOSITORY"
+
+  gh pr edit "$closed_unmerged_pr_number" \
+    --repo "$GITHUB_REPOSITORY" \
+    --title "$pr_title" \
+    --body-file "$temp_pr_body"
+
+  apply_labels_to_pr "$closed_unmerged_pr_number"
+
+  echo "Reopened and updated AI translation PR #${closed_unmerged_pr_number}"
+  exit 0
+fi
+
+set +e
+gh pr create \
+  --repo "$GITHUB_REPOSITORY" \
+  --base "$SOURCE_BRANCH" \
+  --head "$AUTOMATION_BRANCH" \
+  --title "$pr_title" \
+  --body-file "$temp_pr_body"
+create_exit_code=$?
+set -e
+
+new_pr_number="$(find_open_pr_number)"
+
+if [ -z "$new_pr_number" ] && [ "$create_exit_code" -ne 0 ]; then
+  echo "Failed to create AI translation PR and no existing PR was found." >&2
+  exit "$create_exit_code"
+fi
+
+if [ -n "$new_pr_number" ]; then
+  apply_labels_to_pr "$new_pr_number"
+  echo "AI translation PR is available as #${new_pr_number}"
+  exit 0
+fi

--- a/ai-translation-pr/sync-and-publish-ai-translation-pr.sh
+++ b/ai-translation-pr/sync-and-publish-ai-translation-pr.sh
@@ -26,6 +26,8 @@ PR_TITLE_TEMPLATE="${AI_TRANSLATION_PR_TITLE_TEMPLATE:-Update AI translations fo
 
 mkdir -p "$REPORT_ROOT"
 
+repo_root="$(git rev-parse --show-toplevel)"
+
 render_template() {
   local template="$1"
   local pr_number="$2"
@@ -293,6 +295,8 @@ for project_key in "${changed_project_keys[@]}"; do
 
   sync_report="${project_report_dir}/sync-report.json"
   post_check_report="${project_report_dir}/post-check-report.json"
+  sync_report_abs="${repo_root}/${sync_report}"
+  post_check_report_abs="${repo_root}/${post_check_report}"
   project_label="$(project_label_for_key "$project_key")"
 
   echo "Running worphling sync for ${project_label}"
@@ -302,14 +306,17 @@ for project_key in "${changed_project_keys[@]}"; do
     OPENAI_API_KEY="$OPENAI_API_KEY" pnpm exec worphling sync \
       --write \
       --config "$config_name" \
-      --report-file "../../${sync_report}"
+      --report-file "$sync_report_abs"
   )
   sync_exit_code=$?
   set -e
 
   if [ ! -s "$sync_report" ]; then
     echo "worphling sync did not produce a readable report for ${project_label} (exit code ${sync_exit_code})" >&2
-    exit "$sync_exit_code"
+    if [ "$sync_exit_code" -ne 0 ]; then
+      exit "$sync_exit_code"
+    fi
+    exit 1
   fi
 
   echo "worphling sync exit code for ${project_label}: ${sync_exit_code}"
@@ -321,14 +328,17 @@ for project_key in "${changed_project_keys[@]}"; do
     OPENAI_API_KEY="$OPENAI_API_KEY" pnpm exec worphling check \
       --ci \
       --config "$config_name" \
-      --report-file "../../${post_check_report}"
+      --report-file "$post_check_report_abs"
   )
   exit_code=$?
   set -e
 
   if [ ! -s "$post_check_report" ]; then
     echo "Post-sync worphling check did not produce a readable report for ${project_label} (exit code ${exit_code})" >&2
-    exit "$exit_code"
+    if [ "$exit_code" -ne 0 ]; then
+      exit "$exit_code"
+    fi
+    exit 1
   fi
 
   if ! jq -e '.summary.hasChanges != null' "$post_check_report" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Add a new reusable `ai-translation-pr` composite action to the GitHub Actions repository.

This introduces a Worphling-powered AI translation PR workflow that can:

- detect affected Worphling-enabled projects
- run `worphling check`
- create or update a dedicated automation branch and PR
- sync generated translations back into the source branch through a separate PR
- support both monorepos and root-level projects
- generate readable pre-sync and post-sync PR summaries
- clean up stale automation PRs and branches when no translation work is needed

## Changes

- add new `ai-translation-pr` composite action
- add action scripts for:
  - cleanup
  - affected project detection
  - pre-sync checks
  - sync and publish flow
- add dedicated README for the new action
- document the new action in the repository root README
- add `Worphling` to VS Code cSpell words

## Why

This makes AI-driven translation automation reusable across repositories instead of keeping it embedded in a single repo workflow.

It also gives teams a cleaner review flow by opening generated translation changes in a dedicated PR rather than modifying the source PR branch directly.

## Notes

- supports monorepo setups like `apps/*`
- supports root-project setups with `project-roots: "."`
- uses `__PR_NUMBER__` placeholders for configurable PR title and close comment templates