### PR TITLE
Add Playwright shard inputs to `e2e-test-runner` action

### DIFF
--- a/e2e-test-runner/README.md
+++ b/e2e-test-runner/README.md
@@ -7,9 +7,9 @@ Complete reusable GitHub Action that:
 - Installs root dependencies
 - Caches Playwright browsers
 - Installs Playwright deps/browsers on cache miss
-- Runs Playwright tests
-- Uploads Playwright HTML report
-- Marks GitHub Check Run as **completed**
+- Runs Playwright tests (with optional shard mode)
+- Uploads Playwright HTML report — or a `blob-report/` when sharded
+- Marks GitHub Check Run as **completed** — unless a downstream merge job owns completion
 
 ---
 
@@ -36,6 +36,9 @@ If you’re curious how that works, see: [RELAY.md](../RELAY.md)
 | `playwright-version` | –        | Playwright version (`1.53.2`)                                     |
 | `test-command`       | –        | Command used to run E2E tests (default: `pnpm run test:e2e`)      |
 | `working-directory`  | –        | Working directory where E2E tests should run                      |
+| `shard-index`          | –        | 1-based shard index. When set together with `shard-total`, the action runs Playwright in shard mode (see below). |
+| `shard-total`          | –        | Total number of shards. Required alongside `shard-index` to enable shard mode. |
+| `skip-check-completion` | –        | When `'true'`, the action does not mark the GitHub check as completed at the end of the job. Use this when a downstream merge job owns the final check status. |
 
 ---
 
@@ -130,3 +133,133 @@ Uses:
       working-directory: apps/midnight
       test-command: pnpm run test:e2e:ci
 ```
+
+---
+
+## Sharded mode
+
+Sharded mode partitions a single Playwright suite across N independent CI runners using Playwright's built-in [`--shard=<index>/<total>`](https://playwright.dev/docs/test-sharding) flag. Each shard emits a `blob-report/` artifact; a separate merge job stitches them back into one html + junit report.
+
+### When to opt in
+
+- Your Playwright config is **shard-aware** — any per-worker resource (a backend account pool, fixtures stored under `tests/.auth/<n>.json`, etc.) must use a global slot like `(shard-1) * workersPerShard + parallelIndex` so two shards can't alias the same resource. The midnight app does this in [`apps/midnight/tests/e2e/lib/auth/trade-account-pool.ts`](https://github.com/technance-foundation/technance-platform-frontend/blob/main/apps/midnight/tests/e2e/lib/auth/trade-account-pool.ts).
+- Your `test-command` propagates extra args to Playwright. The action appends `-- --shard=<index>/<total>` after `inputs.test-command`, so a wrapper script (e.g. `node scripts/run-e2e-tests.js <app>`) must forward `process.argv.slice(3)` to `playwright test`. Otherwise `--shard` is silently dropped and every shard runs the full suite.
+- Your test count is non-trivial (rough rule of thumb: > ~5 minutes per single-runner run). Below that the sharding overhead (4× setup, install, browser cache restore) dwarfs the savings.
+
+If any of those isn't true, leave `shard-index`/`shard-total` unset and the action runs in its single-runner mode unchanged.
+
+### Per-shard behavior
+
+When `shard-index` AND `shard-total` are both set:
+
+- `--shard=<index>/<total>` is appended to `test-command` (after `--`, so wrapper scripts that respect `--` get the flag).
+- The Playwright config is expected to use the [`blob` reporter](https://playwright.dev/docs/test-reporters#blob-reporter) writing to `blob-report/`.
+- Instead of uploading `playwright-report/`, the action uploads `blob-report/` as `<project>-playwright-blob-report-<shard-index>` so a merge job can pick the artifacts up by glob.
+- If `skip-check-completion: "true"` is also set, the action skips `e2e-check@v1 state: completed` so the merge job can finalize the check exactly once (4 shards otherwise race PATCH `/check-runs` with conflicting outcomes).
+
+### Caller workflow example
+
+```yaml
+jobs:
+    test-e2e-sharded:
+        runs-on: 8core-linux-x64-ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                shard: [1, 2, 3, 4]
+        steps:
+            - uses: actions/checkout@v6
+            - id: app-token
+              uses: tibdex/github-app-token@v2
+              with:
+                  app_id: ${{ vars.E2E_RELAY_GH_APP_ID }}
+                  private_key: ${{ secrets.E2E_RELAY_GH_APP_PRIVATE_KEY }}
+
+            - uses: technance-foundation/github-actions/e2e-test-runner@v1
+              env:
+                  PLAYWRIGHT_WORKERS: "2"
+                  # Read by your shard-aware Playwright config so each
+                  # runner can lease a disjoint slice of any per-worker
+                  # backend resource (account pool, storage state, etc.).
+                  PLAYWRIGHT_SHARD_INDEX: ${{ matrix.shard }}
+                  PLAYWRIGHT_SHARD_TOTAL: ${{ strategy.job-total }}
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
+                  check-run-id: ${{ inputs.check_run_id }}
+                  project: ${{ inputs.project }}
+                  preview-url: ${{ inputs.url }}
+                  npm-token: ${{ secrets.NPM_TOKEN }}
+                  working-directory: ${{ inputs.working_directory }}
+                  test-command: ${{ inputs.test_command }}
+                  shard-index: ${{ matrix.shard }}
+                  shard-total: ${{ strategy.job-total }}
+                  skip-check-completion: "true"
+
+    e2e-merge:
+        runs-on: ubuntu-latest
+        needs: [test-e2e-sharded]
+        if: ${{ always() }}
+        steps:
+            - uses: actions/checkout@v6
+            - id: app-token
+              uses: tibdex/github-app-token@v2
+              with:
+                  app_id: ${{ vars.E2E_RELAY_GH_APP_ID }}
+                  private_key: ${{ secrets.E2E_RELAY_GH_APP_PRIVATE_KEY }}
+
+            - uses: technance-foundation/github-actions/setup@v1
+              with:
+                  node-version: "24"
+                  pnpm-version: "10.32.1"
+                  pnpm-cache: "read"
+                  npm-token: ${{ secrets.NPM_TOKEN }}
+                  install: "pnpm install --no-frozen-lockfile"
+                  build: "false"
+
+            - run: mkdir -p all-blob-reports
+              shell: bash
+
+            - uses: actions/download-artifact@v4
+              with:
+                  pattern: ${{ inputs.project }}-playwright-blob-report-*
+                  path: all-blob-reports
+                  merge-multiple: true
+
+            # PLAYWRIGHT_JUNIT_OUTPUT_FILE points the junit reporter at
+            # a real file; without it the XML goes to stdout and never
+            # makes it into the uploaded artifact.
+            - name: Merge Playwright reports
+              shell: bash
+              working-directory: ${{ inputs.working_directory }}
+              env:
+                  PLAYWRIGHT_JUNIT_OUTPUT_FILE: ${{ github.workspace }}/${{ inputs.working_directory }}/playwright-report/results.xml
+              run: |
+                  mkdir -p playwright-report
+                  pnpm exec playwright merge-reports \
+                      --reporter=list,html,junit \
+                      "${{ github.workspace }}/all-blob-reports"
+
+            - uses: actions/upload-artifact@v4
+              if: ${{ always() }}
+              with:
+                  name: ${{ inputs.project }}-playwright-report
+                  path: ${{ inputs.working_directory }}/playwright-report/
+                  retention-days: 30
+                  if-no-files-found: error
+
+            - uses: technance-foundation/github-actions/e2e-check@v1
+              if: ${{ always() }}
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
+                  check-run-id: ${{ inputs.check_run_id }}
+                  state: completed
+                  job-status: ${{ needs.test-e2e-sharded.result == 'success' && 'success' || 'failure' }}
+                  project: ${{ inputs.project }}
+                  preview-url: ${{ inputs.url }}
+```
+
+### Geometry rules of thumb
+
+- `SHARDS × PLAYWRIGHT_WORKERS ≤ pool size` of any per-worker backend resource. Validate at config-load and fail fast — silent slot aliasing across shards is the worst kind of flake.
+- 2 workers per shard is a safe default; raising it increases IP-level rate limit pressure on the preview environment from a single runner.
+- Shards run in parallel matrix jobs; the wall-clock saving is roughly `1/SHARDS` minus per-shard setup overhead (~30–60s for browser cache restore + install).

--- a/e2e-test-runner/README.md
+++ b/e2e-test-runner/README.md
@@ -142,8 +142,8 @@ Sharded mode partitions a single Playwright suite across N independent CI runner
 
 ### When to opt in
 
-- Your Playwright config is **shard-aware** — any per-worker resource (a backend account pool, fixtures stored under `tests/.auth/<n>.json`, etc.) must use a global slot like `(shard-1) * workersPerShard + parallelIndex` so two shards can't alias the same resource. The midnight app does this in [`apps/midnight/tests/e2e/lib/auth/trade-account-pool.ts`](https://github.com/technance-foundation/technance-platform-frontend/blob/main/apps/midnight/tests/e2e/lib/auth/trade-account-pool.ts).
-- Your `test-command` propagates extra args to Playwright. The action appends `-- --shard=<index>/<total>` after `inputs.test-command`, so a wrapper script (e.g. `node scripts/run-e2e-tests.js <app>`) must forward `process.argv.slice(3)` to `playwright test`. Otherwise `--shard` is silently dropped and every shard runs the full suite.
+- Your Playwright config is **shard-aware** — any per-worker resource (a backend account pool, fixtures stored under `tests/.auth/<n>.json`, etc.) must use a global slot like `(shardIndex - 1) * workersPerShard + parallelIndex` so two shards can't alias the same resource. The action exports `PLAYWRIGHT_SHARD_INDEX` and `PLAYWRIGHT_SHARD_TOTAL` from the matching workflow env so the config can read them at module load.
+- Your `test-command` propagates extra args to Playwright. The action appends `-- --shard=<index>/<total>` after `inputs.test-command`, so any wrapper script the caller invokes (e.g. a `node scripts/run-e2e.js <app>` shim that ultimately spawns `playwright test`) must forward its trailing argv to Playwright. Otherwise `--shard` is silently dropped and every shard runs the full suite.
 - Your test count is non-trivial (rough rule of thumb: > ~5 minutes per single-runner run). Below that the sharding overhead (4× setup, install, browser cache restore) dwarfs the savings.
 
 If any of those isn't true, leave `shard-index`/`shard-total` unset and the action runs in its single-runner mode unchanged.

--- a/e2e-test-runner/action.yml
+++ b/e2e-test-runner/action.yml
@@ -131,12 +131,15 @@ runs:
           working-directory: ${{ inputs.working-directory != '' && inputs.working-directory || format('apps/{0}', inputs.project) }}
           env:
               BASE_URL: ${{ inputs.preview-url }}
+              SHARD_INDEX: ${{ inputs.shard-index }}
+              SHARD_TOTAL: ${{ inputs.shard-total }}
+              TEST_COMMAND: ${{ inputs.test-command }}
           run: |
-              if [ -n "${{ inputs.shard-index }}" ] && [ -n "${{ inputs.shard-total }}" ]; then
-                  echo "Running shard ${{ inputs.shard-index }}/${{ inputs.shard-total }}"
-                  ${{ inputs.test-command }} -- --shard=${{ inputs.shard-index }}/${{ inputs.shard-total }}
+              if [ -n "$SHARD_INDEX" ] && [ -n "$SHARD_TOTAL" ]; then
+                  echo "Running shard $SHARD_INDEX/$SHARD_TOTAL"
+                  eval "$TEST_COMMAND" -- --shard="$SHARD_INDEX/$SHARD_TOTAL"
               else
-                  ${{ inputs.test-command }}
+                  eval "$TEST_COMMAND"
               fi
 
         # -----------------------------------------------------
@@ -145,7 +148,7 @@ runs:
         # -----------------------------------------------------
         - name: Upload Playwright blob report (sharded)
           id: upload-blob-report
-          if: always() && inputs.shard-index != ''
+          if: always() && inputs.shard-index != '' && inputs.shard-total != ''
           uses: actions/upload-artifact@v4
           with:
               name: ${{ inputs.project }}-playwright-blob-report-${{ inputs.shard-index }}
@@ -155,7 +158,7 @@ runs:
 
         - name: Upload Playwright report (un-sharded)
           id: upload-report
-          if: always() && inputs.shard-index == ''
+          if: always() && (inputs.shard-index == '' || inputs.shard-total == '')
           uses: actions/upload-artifact@v4
           with:
               name: ${{ inputs.project }}-playwright-report

--- a/e2e-test-runner/action.yml
+++ b/e2e-test-runner/action.yml
@@ -42,6 +42,21 @@ inputs:
     working-directory:
         description: "Working directory where E2E tests should run"
         required: false
+
+    shard-index:
+        description: "1-based shard index when running Playwright in shard mode. When set together with shard-total, the runner appends `--shard=<index>/<total>` to the test command and uploads a Playwright blob report instead of an html report."
+        required: false
+        default: ""
+
+    shard-total:
+        description: "Total number of shards when running Playwright in shard mode."
+        required: false
+        default: ""
+
+    skip-check-completion:
+        description: "If 'true', the runner does not mark the GitHub check as completed at the end of the job. Use this when a downstream merge job is responsible for completing the check (e.g. after merging blob reports from multiple shards)."
+        required: false
+        default: "false"
 runs:
     using: composite
     steps:
@@ -63,6 +78,10 @@ runs:
         # -----------------------------------------------------
         # MARK CHECK AS IN_PROGRESS
         # -----------------------------------------------------
+        # Note: when sharded, every shard hits this with the same check
+        # run id and state=in_progress. PATCH /check-runs is idempotent
+        # for repeated identical state transitions, so the redundant
+        # calls are safe.
         - name: Mark check as in_progress
           id: mark-in-progress
           uses: technance-foundation/github-actions/e2e-check@v1
@@ -112,14 +131,31 @@ runs:
           working-directory: ${{ inputs.working-directory != '' && inputs.working-directory || format('apps/{0}', inputs.project) }}
           env:
               BASE_URL: ${{ inputs.preview-url }}
-          run: ${{ inputs.test-command }}
+          run: |
+              if [ -n "${{ inputs.shard-index }}" ] && [ -n "${{ inputs.shard-total }}" ]; then
+                  echo "Running shard ${{ inputs.shard-index }}/${{ inputs.shard-total }}"
+                  ${{ inputs.test-command }} -- --shard=${{ inputs.shard-index }}/${{ inputs.shard-total }}
+              else
+                  ${{ inputs.test-command }}
+              fi
 
         # -----------------------------------------------------
-        # REPORT
+        # REPORT (sharded path uploads a blob report; un-sharded
+        # path keeps the legacy html report)
         # -----------------------------------------------------
-        - name: Upload Playwright report
+        - name: Upload Playwright blob report (sharded)
+          id: upload-blob-report
+          if: always() && inputs.shard-index != ''
+          uses: actions/upload-artifact@v4
+          with:
+              name: ${{ inputs.project }}-playwright-blob-report-${{ inputs.shard-index }}
+              path: ${{ inputs.working-directory != '' && format('{0}/blob-report/', inputs.working-directory) || format('apps/{0}/blob-report/', inputs.project) }}
+              retention-days: 7
+              if-no-files-found: error
+
+        - name: Upload Playwright report (un-sharded)
           id: upload-report
-          if: always()
+          if: always() && inputs.shard-index == ''
           uses: actions/upload-artifact@v4
           with:
               name: ${{ inputs.project }}-playwright-report
@@ -127,15 +163,16 @@ runs:
               retention-days: 30
 
         # -----------------------------------------------------
-        # COMPLETE CHECK
+        # COMPLETE CHECK (skipped when a downstream merge job
+        # owns the final check completion)
         # -----------------------------------------------------
         - name: Complete check
-          if: always()
+          if: always() && inputs.skip-check-completion != 'true'
           uses: technance-foundation/github-actions/e2e-check@v1
           with:
               token: ${{ inputs.token }}
               check-run-id: ${{ inputs.check-run-id }}
               state: completed
-              job-status: ${{ (steps.checkout-action.outcome == 'success' && steps.mark-in-progress.outcome == 'success' && steps.setup.outcome == 'success' && steps.cache-playwright.outcome == 'success' && (steps.pw-install.outcome == 'success' || steps.pw-install.outcome == 'skipped') && steps.e2e.outcome == 'success' && steps.upload-report.outcome == 'success') && 'success' || 'failure' }}
+              job-status: ${{ (steps.checkout-action.outcome == 'success' && steps.mark-in-progress.outcome == 'success' && steps.setup.outcome == 'success' && steps.cache-playwright.outcome == 'success' && (steps.pw-install.outcome == 'success' || steps.pw-install.outcome == 'skipped') && steps.e2e.outcome == 'success' && (steps.upload-report.outcome == 'success' || steps.upload-report.outcome == 'skipped') && (steps.upload-blob-report.outcome == 'success' || steps.upload-blob-report.outcome == 'skipped')) && 'success' || 'failure' }}
               project: ${{ inputs.project }}
               preview-url: ${{ inputs.preview-url }}


### PR DESCRIPTION
## Summary

Adds three optional, backwards-compatible inputs to `e2e-test-runner` so callers can run Playwright in shard mode without forking the action.

- `shard-index` and `shard-total` — when both are set, the action appends `--shard=<index>/<total>` to the test command and uploads `blob-report/` (Playwright's blob reporter output) instead of the html report. The blob artifact is named `<project>-playwright-blob-report-<shard-index>` so a downstream merge job can pick it up by glob.
- `skip-check-completion` — when `'true'`, the runner skips the final `e2e-check` `state: completed` step. A merge job is then responsible for finalizing the GitHub check after stitching the per-shard blob reports.

All three default to the un-sharded behavior. Existing callers (eclipse, etc.) keep working with no changes.

## Why

Sister PR on the frontend converts midnight's E2E job into a 4-way matrix and adds a follow-up `e2e-merge` job: technance-foundation/technance-platform-frontend#3270.

That PR cannot use `e2e-test-runner@main` until this lands — without these inputs the action runs the full suite on every shard and uploads four artifacts under the same `<project>-playwright-report` name (artifact-name collision in actions/upload-artifact@v4).

## Test plan

- [ ] Frontend PR #3270 dispatches `e2e.yaml` against `e2e-test-runner@feat/playwright-sharding` (or this branch after merge) and produces 4 disjoint per-shard blob artifacts plus one merged report.
- [ ] Eclipse / other un-sharded callers using `e2e-test-runner@main` (no shard inputs) still upload `<project>-playwright-report` with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
