### PR TITLE
Add `e2e-bootstrap` action, pin internal refs to `@main`, make `npm-token` optional

### DIFF
--- a/e2e-bootstrap/README.md
+++ b/e2e-bootstrap/README.md
@@ -1,0 +1,76 @@
+# E2E Test Bootstrap
+
+Composite action that primes the pnpm store cache and the Playwright browser cache so a downstream matrix of sharded test jobs starts against **warm** caches instead of all racing a cold cache miss in parallel.
+
+## When to use it
+
+Use it as a prerequisite job for any workflow whose `e2e-test-runner` shards run in a `strategy.matrix`. Without a bootstrap, 4 parallel shards each independently:
+
+- run a full `pnpm install` against a cold store cache, and
+- run `playwright install --with-deps chromium` against a cold browser cache.
+
+With this action in a job the shards `needs:`, the install + browser download happen once and the shards consume the populated caches via the same keys that `e2e-test-runner` already uses.
+
+## Inputs
+
+| Name                 | Required | Default    | Description                                                                                                                                            |
+| -------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `npm-token`          | ✔️       | —          | NPM token for installing private dependencies                                                                                                          |
+| `node-version`       | –        | `22`       | Node.js version                                                                                                                                        |
+| `pnpm-version`       | –        | `10.15.0`  | pnpm version. Used only if `package.json` does not pin `packageManager`                                                                                |
+| `playwright-version` | –        | `1.53.2`   | Discriminator in the browser-cache key. **Must match** the `playwright-version` passed to `e2e-test-runner` in the shards, or the shards cache-miss    |
+
+## Cache keys
+
+This action writes to two caches whose keys must remain in lockstep with the corresponding consumers in `e2e-test-runner`:
+
+- **pnpm store** — `${{ runner.os }}-node-<node-version>-pnpm-store-<package.json hash>-<pnpm-lock.yaml hash>` (delegated to the shared `setup` action).
+- **Playwright browsers** — `${{ runner.os }}-playwright-<playwright-version>-<pnpm-lock.yaml hash>`.
+
+If either key formula changes here it must change in `e2e-test-runner` too, otherwise the shards will not hit the entries this job writes.
+
+## Usage
+
+```yaml
+jobs:
+    bootstrap:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1
+
+            - uses: technance-foundation/github-actions/e2e-bootstrap@v1
+              with:
+                  node-version: "24"
+                  pnpm-version: "11.0.9"
+                  npm-token: ${{ secrets.NPM_TOKEN }}
+
+    test-e2e-sharded:
+        needs: bootstrap
+        runs-on: 8core-linux-x64-ubuntu-latest
+        strategy:
+            fail-fast: true
+            matrix:
+                shard: [1, 2, 3, 4]
+        steps:
+            - uses: actions/checkout@v6
+            - uses: technance-foundation/github-actions/e2e-test-runner@v1
+              with:
+                  # ... shard inputs as usual. pnpm + browser caches
+                  # are already populated, so the runner's own setup
+                  # steps will restore them instead of installing.
+                  ...
+```
+
+Pair with `strategy.fail-fast: true` at the matrix level so a failing shard cancels its siblings — bootstrap on its own only addresses duplicated *setup* time, not duplicated *test* time after a failure.
+
+## Why not put this in `e2e-test-runner`?
+
+`e2e-test-runner` runs **per shard**. The whole point of the bootstrap is that it must run **once**, before the matrix fans out — that's only expressible as a separate job. The two actions deliberately share the same cache-key formulas so they hand off cleanly.
+
+## Caveats
+
+- This action does not run `actions/checkout`. The caller must check out the repo first so the `pnpm-lock.yaml` exists for the cache key hash and for `pnpm install` to read.
+- The pnpm cache is portable across runner sizes, so it's fine to bootstrap on `ubuntu-latest` and consume from `8core-linux-x64-ubuntu-latest` shards. Bootstrapping on a smaller runner saves CI minutes for the same effect.
+- If `playwright-version` here differs from the value in `e2e-test-runner`, the bootstrap is silently wasted — the shards will produce a different cache key and reinstall. Keep them in lockstep.

--- a/e2e-bootstrap/README.md
+++ b/e2e-bootstrap/README.md
@@ -15,7 +15,7 @@ With this action in a job the shards `needs:`, the install + browser download ha
 
 | Name                 | Required | Default    | Description                                                                                                                                            |
 | -------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `npm-token`          | ✔️       | —          | NPM token for installing private dependencies                                                                                                          |
+| `npm-token`          | –        | `""`       | NPM token for installing private dependencies. Optional; leave empty to skip `.npmrc` auth when only public packages are needed                        |
 | `node-version`       | –        | `22`       | Node.js version                                                                                                                                        |
 | `pnpm-version`       | –        | `10.15.0`  | pnpm version. Used only if `package.json` does not pin `packageManager`                                                                                |
 | `playwright-version` | –        | `1.53.2`   | Discriminator in the browser-cache key. **Must match** the `playwright-version` passed to `e2e-test-runner` in the shards, or the shards cache-miss    |
@@ -40,7 +40,7 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - uses: technance-foundation/github-actions/e2e-bootstrap@v1
+            - uses: technance-foundation/github-actions/e2e-bootstrap@main
               with:
                   node-version: "24"
                   pnpm-version: "11.0.9"
@@ -55,7 +55,7 @@ jobs:
                 shard: [1, 2, 3, 4]
         steps:
             - uses: actions/checkout@v6
-            - uses: technance-foundation/github-actions/e2e-test-runner@v1
+            - uses: technance-foundation/github-actions/e2e-test-runner@main
               with:
                   # ... shard inputs as usual. pnpm + browser caches
                   # are already populated, so the runner's own setup

--- a/e2e-bootstrap/action.yml
+++ b/e2e-bootstrap/action.yml
@@ -1,0 +1,60 @@
+name: "E2E Test Bootstrap"
+description: "Primes the pnpm store cache and the Playwright browser cache exactly once so downstream matrix-sharded test jobs start against warm caches instead of all racing a cold cache miss in parallel."
+
+inputs:
+    node-version:
+        description: "Node.js version"
+        default: "22"
+
+    pnpm-version:
+        description: "PNPM version (used only when `package.json` does not pin a `packageManager` field)"
+        default: "10.15.0"
+
+    playwright-version:
+        description: "Playwright version. Used as the discriminator in the browser-cache key, so it MUST match the `playwright-version` passed to `e2e-test-runner` in the downstream shards — otherwise the shards cache-miss and re-install browsers."
+        default: "1.53.2"
+
+    npm-token:
+        description: "NPM token for installing private dependencies"
+        required: true
+
+runs:
+    using: composite
+    steps:
+        # -----------------------------------------------------
+        # WARM PNPM STORE CACHE
+        # -----------------------------------------------------
+        # `pnpm-cache: "write"` produces the same key the downstream
+        # `e2e-test-runner` setup step expects; that step uses
+        # `actions/cache@v4` (write mode) too, so when all 4 shards run
+        # in parallel they restore from this populated entry instead of
+        # each performing a full network install.
+        - name: Setup & install (warm pnpm store cache)
+          uses: technance-foundation/github-actions/setup@v1
+          with:
+              node-version: ${{ inputs.node-version }}
+              pnpm-version: ${{ inputs.pnpm-version }}
+              npm-token: ${{ inputs.npm-token }}
+              pnpm-cache: "write"
+              install: "pnpm install --no-frozen-lockfile"
+              build: "false"
+
+        # -----------------------------------------------------
+        # WARM PLAYWRIGHT BROWSER CACHE
+        # -----------------------------------------------------
+        # Cache key MUST stay byte-identical to the one in
+        # `e2e-test-runner/action.yml` so the shards hit the entry
+        # this job writes. If you change one, change both.
+        - name: Cache Playwright browsers (write)
+          id: cache-playwright
+          uses: actions/cache@v5
+          with:
+              path: ~/.cache/ms-playwright
+              key: ${{ runner.os }}-playwright-${{ inputs.playwright-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+              restore-keys: |
+                  ${{ runner.os }}-playwright-${{ inputs.playwright-version }}-
+
+        - name: Install Playwright browsers (cache miss)
+          if: steps.cache-playwright.outputs.cache-hit != 'true'
+          shell: bash
+          run: pnpm exec playwright install --with-deps chromium

--- a/e2e-bootstrap/action.yml
+++ b/e2e-bootstrap/action.yml
@@ -15,8 +15,9 @@ inputs:
         default: "1.53.2"
 
     npm-token:
-        description: "NPM token for installing private dependencies"
-        required: true
+        description: "NPM token for installing private dependencies. Leave empty to skip .npmrc auth (e.g. when the project pulls only public packages)."
+        required: false
+        default: ""
 
 runs:
     using: composite
@@ -30,7 +31,7 @@ runs:
         # in parallel they restore from this populated entry instead of
         # each performing a full network install.
         - name: Setup & install (warm pnpm store cache)
-          uses: technance-foundation/github-actions/setup@v1
+          uses: technance-foundation/github-actions/setup@main
           with:
               node-version: ${{ inputs.node-version }}
               pnpm-version: ${{ inputs.pnpm-version }}

--- a/e2e-check/README.md
+++ b/e2e-check/README.md
@@ -34,7 +34,7 @@ If you want to understand the bigger picture of how checks are created and trigg
 ### Mark check as in_progress
 
 ```yaml
-- uses: technance-foundation/github-actions/e2e-check@v1
+- uses: technance-foundation/github-actions/e2e-check@main
   with:
       token: ${{ steps.app-token.outputs.token }}
       check-run-id: ${{ inputs.check_run_id }}
@@ -44,7 +44,7 @@ If you want to understand the bigger picture of how checks are created and trigg
 ### Mark check as completed
 
 ```yaml
-- uses: technance-foundation/github-actions/e2e-check@v1
+- uses: technance-foundation/github-actions/e2e-check@main
   if: always()
   with:
       token: ${{ steps.app-token.outputs.token }}

--- a/e2e-check/action.yml
+++ b/e2e-check/action.yml
@@ -36,7 +36,7 @@ runs:
           uses: actions/checkout@v6
           with:
               repository: technance-foundation/github-actions
-              ref: v1
+              ref: main
               path: ./.github/actions/github-actions
               sparse-checkout: |
                   e2e-check

--- a/e2e-test-runner/README.md
+++ b/e2e-test-runner/README.md
@@ -30,7 +30,7 @@ If you’re curious how that works, see: [RELAY.md](../RELAY.md)
 | `check-run-id`       | ✔️       | The GitHub Check Run ID                                           |
 | `project`            | ✔️       | Project/app name used for reporting and default working directory |
 | `preview-url`        | ✔️       | BASE_URL for testing                                              |
-| `npm-token`          | ✔️       | NPM token for installing private dependencies                     |
+| `npm-token`          | –        | NPM token for installing private dependencies. Optional; leave empty to skip `.npmrc` auth when only public packages are needed |
 | `node-version`       | –        | Node version (`22`)                                               |
 | `pnpm-version`       | –        | pnpm version (`10.15.0`)                                          |
 | `playwright-version` | –        | Playwright version (`1.53.2`)                                     |
@@ -64,7 +64,7 @@ Uses:
 - `apps/<project>` as working directory
 
 ```yaml
-- uses: technance-foundation/github-actions/e2e-test-runner@v1
+- uses: technance-foundation/github-actions/e2e-test-runner@main
   with:
       token: ${{ steps.app-token.outputs.token }}
       check-run-id: ${{ inputs.check_run_id }}
@@ -78,7 +78,7 @@ Uses:
 ### Custom test command
 
 ```yaml
-- uses: technance-foundation/github-actions/e2e-test-runner@v1
+- uses: technance-foundation/github-actions/e2e-test-runner@main
   with:
       token: ${{ steps.app-token.outputs.token }}
       check-run-id: ${{ inputs.check_run_id }}
@@ -93,7 +93,7 @@ Uses:
 ### Custom working directory
 
 ```yaml
-- uses: technance-foundation/github-actions/e2e-test-runner@v1
+- uses: technance-foundation/github-actions/e2e-test-runner@main
   with:
       token: ${{ steps.app-token.outputs.token }}
       check-run-id: ${{ inputs.check_run_id }}
@@ -108,7 +108,7 @@ Uses:
 ### Example: run a specific test file
 
 ```yaml
-- uses: technance-foundation/github-actions/e2e-test-runner@v1
+- uses: technance-foundation/github-actions/e2e-test-runner@main
   with:
       token: ${{ steps.app-token.outputs.token }}
       check-run-id: ${{ inputs.check_run_id }}
@@ -123,7 +123,7 @@ Uses:
 ### Example: custom working directory and custom test command
 
 ```yaml
-- uses: technance-foundation/github-actions/e2e-test-runner@v1
+- uses: technance-foundation/github-actions/e2e-test-runner@main
   with:
       token: ${{ steps.app-token.outputs.token }}
       check-run-id: ${{ inputs.check_run_id }}
@@ -175,7 +175,7 @@ jobs:
                   app_id: ${{ vars.E2E_RELAY_GH_APP_ID }}
                   private_key: ${{ secrets.E2E_RELAY_GH_APP_PRIVATE_KEY }}
 
-            - uses: technance-foundation/github-actions/e2e-test-runner@v1
+            - uses: technance-foundation/github-actions/e2e-test-runner@main
               env:
                   PLAYWRIGHT_WORKERS: "2"
                   # Read by your shard-aware Playwright config so each
@@ -207,7 +207,7 @@ jobs:
                   app_id: ${{ vars.E2E_RELAY_GH_APP_ID }}
                   private_key: ${{ secrets.E2E_RELAY_GH_APP_PRIVATE_KEY }}
 
-            - uses: technance-foundation/github-actions/setup@v1
+            - uses: technance-foundation/github-actions/setup@main
               with:
                   node-version: "24"
                   pnpm-version: "10.32.1"
@@ -247,7 +247,7 @@ jobs:
                   retention-days: 30
                   if-no-files-found: error
 
-            - uses: technance-foundation/github-actions/e2e-check@v1
+            - uses: technance-foundation/github-actions/e2e-check@main
               if: ${{ always() }}
               with:
                   token: ${{ steps.app-token.outputs.token }}

--- a/e2e-test-runner/action.yml
+++ b/e2e-test-runner/action.yml
@@ -31,8 +31,9 @@ inputs:
         default: "1.53.2"
 
     npm-token:
-        description: "NPM token for installing private dependencies"
-        required: true
+        description: "NPM token for installing private dependencies. Leave empty to skip .npmrc auth (e.g. when the project pulls only public packages)."
+        required: false
+        default: ""
 
     test-command:
         description: "Command used to run E2E tests"
@@ -68,7 +69,7 @@ runs:
           uses: actions/checkout@v6
           with:
               repository: technance-foundation/github-actions
-              ref: v1
+              ref: main
               path: ./.github/actions/github-actions
               sparse-checkout: |
                   e2e-check
@@ -84,7 +85,7 @@ runs:
         # calls are safe.
         - name: Mark check as in_progress
           id: mark-in-progress
-          uses: technance-foundation/github-actions/e2e-check@v1
+          uses: technance-foundation/github-actions/e2e-check@main
           with:
               token: ${{ inputs.token }}
               check-run-id: ${{ inputs.check-run-id }}
@@ -95,7 +96,7 @@ runs:
         # -----------------------------------------------------
         - name: Setup & install (root)
           id: setup
-          uses: technance-foundation/github-actions/setup@v1
+          uses: technance-foundation/github-actions/setup@main
           with:
               node-version: ${{ inputs.node-version }}
               pnpm-version: ${{ inputs.pnpm-version }}
@@ -171,7 +172,7 @@ runs:
         # -----------------------------------------------------
         - name: Complete check
           if: always() && inputs.skip-check-completion != 'true'
-          uses: technance-foundation/github-actions/e2e-check@v1
+          uses: technance-foundation/github-actions/e2e-check@main
           with:
               token: ${{ inputs.token }}
               check-run-id: ${{ inputs.check-run-id }}

--- a/load-env/README.md
+++ b/load-env/README.md
@@ -30,7 +30,7 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: Load environment variables
-              uses: technance-foundation/github-actions/load-env@v1
+              uses: technance-foundation/github-actions/load-env@main
               with:
                   file: .env.ci
 

--- a/publish-any-commit/README.md
+++ b/publish-any-commit/README.md
@@ -26,7 +26,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: technance-foundation/github-actions/publish-any-commit@v1
+            - uses: technance-foundation/github-actions/publish-any-commit@main
 ```
 
 ## With NPM Authentication
@@ -34,7 +34,7 @@ jobs:
 If you need to authenticate with a private NPM registry:
 
 ```yaml
-- uses: technance-foundation/github-actions/publish-any-commit@v1
+- uses: technance-foundation/github-actions/publish-any-commit@main
   with:
       npm-token: ${{ secrets.NPM_TOKEN }}
 ```
@@ -42,7 +42,7 @@ If you need to authenticate with a private NPM registry:
 ## Target a Single Package
 
 ```yaml
-- uses: technance-foundation/github-actions/publish-any-commit@v1
+- uses: technance-foundation/github-actions/publish-any-commit@main
   with:
       package-paths: "./packages/worphling"
 ```
@@ -50,7 +50,7 @@ If you need to authenticate with a private NPM registry:
 ## Target Multiple Packages
 
 ```yaml
-- uses: technance-foundation/github-actions/publish-any-commit@v1
+- uses: technance-foundation/github-actions/publish-any-commit@main
   with:
       package-paths: |
           ./packages/nova

--- a/release/README.md
+++ b/release/README.md
@@ -208,7 +208,7 @@ jobs:
 
         steps:
             - name: Run automated release
-              uses: technance-foundation/github-actions/release@v2
+              uses: technance-foundation/github-actions/release@main
               with:
                   node-version: "22"
                   pnpm-version: "10.15.0"

--- a/setup/README.md
+++ b/setup/README.md
@@ -19,7 +19,7 @@ It handles environment setup, dependency installation, caching, and optional bui
 | `node-version`      | The version of Node.js to use. Default is `20`.                                                                                  |
 | `pnpm-version`      | The version of pnpm to use. Default is `9.0.6`.                                                                                  |
 | `pnpm-cache`        | Cache strategy can be one of `read`, `write`, or `off`. Default is `write`                                                       |
-| `npm-token`         | NPM token for authenticating to the NPM registry. Required if installing from private packages.                                  |
+| `npm-token`         | NPM token for authenticating to the NPM registry. Optional; leave empty when no private packages are needed and the `.npmrc` auth step is skipped entirely. |
 | `install`           | Either `"false"` to skip installing dependencies, or the install command to run. Default is `pnpm install --no-frozen-lockfile`. |
 | `build`             | Either `"false"` to skip building, or the build command to run. Default is `pnpm build`.                                         |
 | `working-directory` | The working directory to run the commands in. Default is `.`.                                                                    |
@@ -39,7 +39,7 @@ jobs:
     setup:
         runs-on: ubuntu-latest
         steps:
-            - uses: technance-foundation/github-actions/setup@v1
+            - uses: technance-foundation/github-actions/setup@main
               with:
                   node-version: "20"
                   pnpm-version: "10.6.5"
@@ -51,7 +51,7 @@ jobs:
 If you want to skip install or build:
 
 ```yaml
-- uses: technance-foundation/github-actions/setup@v1
+- uses: technance-foundation/github-actions/setup@main
   with:
   npm-token: ${{ secrets.NPM_TOKEN }}
   install: "false"
@@ -63,7 +63,7 @@ If you want to skip install or build:
 You can override the defaults:
 
 ```yaml
-- uses: technance-foundation/github-actions/setup@v1
+- uses: technance-foundation/github-actions/setup@main
   with:
   npm-token: ${{ secrets.NPM_TOKEN }}
   install: "pnpm install --frozen-lockfile"
@@ -75,7 +75,7 @@ You can override the defaults:
 If your project is in a subdirectory:
 
 ```yaml
-- uses: technance-foundation/github-actions/setup@v1
+- uses: technance-foundation/github-actions/setup@main
   with:
       npm-token: ${{ secrets.NPM_TOKEN }}
       working-directory: "./sdks/node"

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -12,8 +12,9 @@ inputs:
         description: "Cache strategy can be one of `read`, `write`, or `off`"
         default: "write"
     npm-token:
-        description: "NPM token for authenticating to the NPM registry"
-        required: true
+        description: "NPM token for authenticating to the NPM registry. Leave empty to skip .npmrc auth entirely (e.g. when no private packages are needed)."
+        required: false
+        default: ""
     install:
         description: "Either false to skip or the build command to run, default is `pnpm install --no-frozen-lockfile`"
         default: "pnpm install --no-frozen-lockfile"
@@ -99,6 +100,7 @@ runs:
                   ${{ runner.os }}-node-${{ inputs.node-version }}-pnpm-store-
 
         - name: Authenticate NPM registry
+          if: ${{ inputs.npm-token != '' }}
           shell: bash
           run: echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token }}" > ~/.npmrc
 

--- a/telegram-notifications/README.md
+++ b/telegram-notifications/README.md
@@ -30,7 +30,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Telegram Notify
-              uses: technance-foundation/github-actions/telegram-notifications@v1
+              uses: technance-foundation/github-actions/telegram-notifications@main
               with:
                   to: ${{ secrets.TELEGRAM_TO }}
                   token: ${{ secrets.TELEGRAM_TOKEN }}


### PR DESCRIPTION
## Summary

Three coordinated cleanups in this repo:

1. **New `e2e-bootstrap` composite action.** Warms the pnpm store cache + Playwright browser cache so a downstream matrix of sharded `e2e-test-runner` jobs starts against warm caches instead of all racing a cold cache miss in parallel.
2. **All in-repo refs use `@main`.** Every composite action that calls another action in this repo, and every example in every README, now points at `@main` — the convention consumers already use externally. The stale `@v1` (and one `@v2` in `release/README.md`) refs are gone.
3. **`npm-token` is now optional everywhere.** The three actions that had it `required: true` (`setup`, `e2e-test-runner`, and the new `e2e-bootstrap`) now have `required: false` with `default: ""`, matching the pattern already used in `publish-any-commit`, `release`, and `ai-translation-pr`. The `setup` action's NPM-auth step is guarded on `inputs.npm-token != ''` so an empty token no longer writes a bogus `_authToken=` line into `~/.npmrc`. The corresponding README input tables are updated.

## What changed

### New action: `e2e-bootstrap/`

- `action.yml` — three steps:
  1. `setup@main` with `pnpm-cache: "write"` + `pnpm install --no-frozen-lockfile` (warms the pnpm store cache).
  2. `actions/cache@v5` for `~/.cache/ms-playwright` using the same key formula `e2e-test-runner` uses (`${{ runner.os }}-playwright-<playwright-version>-<pnpm-lock.yaml hash>`).
  3. `pnpm exec playwright install --with-deps chromium` only on cache miss.
- `README.md` — purpose, inputs, cache-key contract with `e2e-test-runner`, usage example, caveats.

### Ref flips in `action.yml`s: `@v1` → `@main`

| File | Step | Before | After |
| ---- | ---- | ------ | ----- |
| `e2e-bootstrap/action.yml` | Setup & install | `setup@v1` | `setup@main` |
| `e2e-test-runner/action.yml` | Setup & install | `setup@v1` | `setup@main` |
| `e2e-test-runner/action.yml` | Mark check as in_progress | `e2e-check@v1` | `e2e-check@main` |
| `e2e-test-runner/action.yml` | Complete check | `e2e-check@v1` | `e2e-check@main` |
| `e2e-test-runner/action.yml` | Sparse checkout of action source | `ref: v1` | `ref: main` |
| `e2e-check/action.yml` | Sparse checkout of action source | `ref: v1` | `ref: main` |

### Ref flips in READMEs

Updated examples in `setup/README.md`, `e2e-check/README.md`, `e2e-test-runner/README.md`, `e2e-bootstrap/README.md`, `publish-any-commit/README.md`, `load-env/README.md`, `telegram-notifications/README.md`, and `release/README.md`. Third-party refs like `changesets/action@v1` are intentionally left alone — they're not our refs.

### `npm-token` now optional

| Action | Before | After |
| ------ | ------ | ----- |
| `setup` | `required: true` | `required: false`, `default: ""`, NPM-auth step guarded on non-empty |
| `e2e-test-runner` | `required: true` | `required: false`, `default: ""` |
| `e2e-bootstrap` | `required: true` | `required: false`, `default: ""` |

`publish-any-commit`, `release`, and `ai-translation-pr` already had it optional and were not touched. README input tables in `setup`, `e2e-test-runner`, and `e2e-bootstrap` are updated to reflect "Optional" + the empty-token behavior.

## Audit confirms nothing remaining

After this PR:

```
$ grep -rn "technance-foundation/github-actions/.*@v[0-9]" . --include="*.md" --include="*.yml"
(none)

$ grep -rn "ref: v1" . --include="*.yml"
(none)

$ grep -B2 "required: true" */action.yml | grep -B1 "npm-token"
(none)
```

## Why `e2e-bootstrap` is its own action (and not folded into `e2e-test-runner`)

`e2e-test-runner` runs **per shard**. A bootstrap must run **once**, before the matrix fans out — that's only expressible as a separate job and therefore wants its own composite action. The two actions deliberately share the same cache-key formulas as their contract, so the handoff between writer (bootstrap) and reader (shards) is implicit.

`e2e-test-runner`'s setup steps stay in place because its final `Complete check` step's `job-status` expression aggregates over `steps.setup.outcome`, `steps.cache-playwright.outcome`, and `steps.pw-install.outcome`. Moving those steps into a nested composite action erases the step IDs and breaks that aggregation. A future refactor can DRY the two by introducing a lower-level setup action or per-step outputs — out of scope here.

## Cache-key contract

The two cache keys produced by `e2e-bootstrap` must stay byte-identical to those in `e2e-test-runner/action.yml`:

- pnpm store key — delegated to the `setup` action, identical formula on both sides.
- Playwright browsers — `${{ runner.os }}-playwright-${{ inputs.playwright-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}`.

If either formula changes, both actions must be updated in lockstep. The new README spells this out and the `action.yml`s have inline comments calling it out.

## Test plan

- A consumer workflow that adds a `bootstrap` job calling `e2e-bootstrap@main` and `needs: bootstrap` on its sharded matrix should observe: the bootstrap job runs `pnpm install` and `playwright install` once; each shard's `e2e-test-runner` setup hits the pnpm store cache, and its Playwright browser cache step reports `cache-hit: true` (skipping the browser install).
- The un-sharded `e2e-test-runner` path is unaffected — consumers that don't add the bootstrap job continue to behave exactly as before.
- A consumer that does **not** pass `npm-token` to `setup` / `e2e-test-runner` / `e2e-bootstrap` should no longer fail — the NPM-auth step is skipped, the rest of setup proceeds against the public registry.
