### PR TITLE
Create a GitHub Release for every pushed tag

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -8,7 +8,8 @@ This composite GitHub Action implements a **fully automated release flow** using
 - Commits and pushes version bumps back to `main`
 - Publishes packages to npm
 - Creates **git tags** for released packages
-- Automatically **excludes `private: true` packages** from commit messages and tags
+- Creates a **GitHub Release** per released package, with the matching `CHANGELOG.md` section as the body (prerelease semver bumps are flagged accordingly)
+- Automatically **excludes `private: true` packages** from commit messages, tags, and GitHub Releases
 - Does **not** open PRs or rely on `changesets/action@v1`
 
 > ⚠️ Important: Your workflow **must skip this action when the commit author is `github-actions[bot]`** to avoid infinite loops.
@@ -127,8 +128,22 @@ Packages with `"private": true` in their `package.json` are automatically exclud
 
 - The generated commit message
 - Git tags
+- GitHub Releases
 
-This prevents internal-only workspaces (for example tooling packages) from being tagged as releases.
+This prevents internal-only workspaces (for example tooling packages) from being tagged or released.
+
+---
+
+## 📝 GitHub Releases
+
+For each tag the action pushes, it also creates a corresponding **GitHub Release**:
+
+- **Title** — the tag itself (`@scope/pkg@version`).
+- **Body** — the matching `## <version>` section of that package's `CHANGELOG.md`, which Changesets has just regenerated. If no section is found, the body falls back to a one-line "Released `@scope/pkg@version` to the npm registry."
+- **Prerelease** — flagged automatically when the new version contains a SemVer prerelease suffix (`1.2.3-alpha.0`, `1.2.3-rc.1`, …), so it doesn't replace the repo's "Latest release".
+- **Idempotent** — if a release with the same tag already exists (e.g. created by hand previously), the step skips it instead of failing.
+
+The release is created via `gh release create --verify-tag`, using the same token that pushed the tag (`push-token` if provided, otherwise `github.token`).
 
 ---
 
@@ -239,7 +254,8 @@ jobs:
 
 10. Publish packages (`publish-command`)
 11. Create and push git tags (from the filtered release list)
-12. Set outputs and clean up artifacts
+12. Create GitHub Releases for each tag, sourcing the body from the matching `CHANGELOG.md` section
+13. Set outputs and clean up artifacts
 
 ---
 

--- a/release/action.yml
+++ b/release/action.yml
@@ -414,7 +414,7 @@ runs:
                 fi
 
                 pkg_json="$(
-                  find . -path ./node_modules -prune -o -name package.json -print 2>/dev/null \
+                  find . \( -type d -name node_modules -prune \) -o -name package.json -print 2>/dev/null \
                     | xargs -I {} sh -c 'if [ "$(jq -r ".name // empty" "{}" 2>/dev/null)" = "'"$name"'" ]; then echo "{}"; fi' \
                     | head -n 1
                 )"

--- a/release/action.yml
+++ b/release/action.yml
@@ -130,6 +130,11 @@ runs:
                 echo "If you're using a self-hosted runner, install jq (and ensure bash is available)."
                 exit 1
               fi
+              if ! command -v gh >/dev/null 2>&1; then
+                echo "gh (GitHub CLI) is required but was not found on PATH."
+                echo "If you're using a self-hosted runner, install gh from https://cli.github.com/."
+                exit 1
+              fi
 
         - name: Authenticate NPM registry (optional)
           if: ${{ inputs.npm-token != '' }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -384,6 +384,74 @@ runs:
 
               git push origin --tags
 
+        - name: Create GitHub Releases for released packages
+          if: ${{ steps.changeset-status.outputs.has_changesets == 'true' && steps.git-diff.outputs.has_changes == 'true' }}
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}
+          env:
+              GH_TOKEN: ${{ inputs.push-token != '' && inputs.push-token || github.token }}
+          run: |
+              set -euo pipefail
+
+              if [ ! -f release.filtered.json ]; then
+                echo "release.filtered.json not found; cannot create GitHub Releases."
+                exit 0
+              fi
+
+              while IFS= read -r row; do
+                name="$(echo "$row" | jq -r '.name')"
+                version="$(echo "$row" | jq -r '.newVersion')"
+                tag="${name}@${version}"
+
+                if gh release view "$tag" --json tagName >/dev/null 2>&1; then
+                  echo "GitHub Release for $tag already exists — skipping."
+                  continue
+                fi
+
+                pkg_json="$(
+                  find . -path ./node_modules -prune -o -name package.json -print 2>/dev/null \
+                    | xargs -I {} sh -c 'if [ "$(jq -r ".name // empty" "{}" 2>/dev/null)" = "'"$name"'" ]; then echo "{}"; fi' \
+                    | head -n 1
+                )"
+
+                changelog_path=""
+                if [ -n "$pkg_json" ]; then
+                  changelog_path="$(dirname "$pkg_json")/CHANGELOG.md"
+                fi
+
+                notes_file="$(mktemp)"
+                if [ -n "$changelog_path" ] && [ -f "$changelog_path" ]; then
+                  awk -v ver="$version" '
+                    /^## / {
+                      if (in_section) exit
+                      if ($0 == "## " ver) { in_section = 1; next }
+                    }
+                    in_section { print }
+                  ' "$changelog_path" > "$notes_file"
+                fi
+
+                if [ ! -s "$notes_file" ]; then
+                  echo "::warning::No CHANGELOG section for $tag; using a generic release body."
+                  printf 'Released `%s` to the npm registry.\n' "$tag" > "$notes_file"
+                fi
+
+                prerelease_flag=()
+                # Any SemVer build metadata or prerelease suffix (e.g. `1.2.3-alpha.0`)
+                # gets marked as a prerelease so it doesn't replace "Latest release".
+                if [[ "$version" == *-* ]]; then
+                  prerelease_flag=(--prerelease)
+                fi
+
+                echo "Creating GitHub Release for $tag (prerelease=${prerelease_flag:+yes})"
+                gh release create "$tag" \
+                  --title "$tag" \
+                  --notes-file "$notes_file" \
+                  --verify-tag \
+                  "${prerelease_flag[@]}"
+
+                rm -f "$notes_file"
+              done < <(jq -c '.releases[]' release.filtered.json)
+
         - name: Set outputs
           id: set-output
           shell: bash

--- a/release/action.yml
+++ b/release/action.yml
@@ -399,8 +399,8 @@ runs:
               set -euo pipefail
 
               if [ ! -f release.filtered.json ]; then
-                echo "release.filtered.json not found; cannot create GitHub Releases."
-                exit 0
+                echo "release.filtered.json not found; cannot create GitHub Releases." >&2
+                exit 1
               fi
 
               while IFS= read -r row; do


### PR DESCRIPTION
## Summary

- Each release now produces a GitHub Release with the package's freshly-regenerated `CHANGELOG.md` section as the body, instead of just a lightweight git tag.
- Prerelease semver bumps (e.g. `1.2.3-alpha.0`) are flagged as prerelease automatically so they don't replace the repo's "Latest release".
- Idempotent — skips any tag that already has a release, so repos with pre-existing hand-authored releases don't break.

## Why

The action used to push lightweight git tags and stop there. The repo's Releases tab stayed empty, and the per-package `CHANGELOG.md` that Changesets regenerates on every bump never surfaced anywhere consumers could read or subscribe to. In practice every downstream repo using this action ended up either ignoring releases entirely or hand-authoring them after the fact — exactly the toil this action was supposed to remove.

## Implementation

New step \`Create GitHub Releases for released packages\`, inserted between \`Create git tags\` and \`Set outputs\`:

1. Iterates \`release.filtered.json\` (already filtered for ignored + private packages in an earlier step).
2. Locates each package's directory by reverse-mapping its \`.name\` through every workspace \`package.json\` (so it doesn't have to know about the workspace layout).
3. Slices that package's \`CHANGELOG.md\` to the section matching \`## <newVersion>\` via awk and feeds it as the release body. Falls back to a one-line generic body if no section is found.
4. Detects a SemVer prerelease suffix (\`*-*\`) on the new version and passes \`--prerelease\` accordingly.
5. Checks for an existing release on the same tag (\`gh release view\`) before creating, so repos with hand-authored releases for older tags don't trip this on re-runs.
6. Uses \`push-token\` when provided (so the bot identity attributes), otherwise falls back to \`github.token\`.

README updated to document the new behavior, the prerelease flag, and the idempotency.

## Backwards compatibility

Existing downstream repos (e.g. \`technance-foundation/platform-sdk\`) keep working without any workflow change. For tags they hand-authored releases on previously, the new step's existence check skips them silently. For new tags going forward, releases get auto-created — which is the goal.

The job permission requirement is unchanged: any caller that already had \`contents: write\` (needed for pushing the bump commit and tags) is also allowed to create releases. No new secrets or permissions needed.

## Test plan

- [x] Locally validated \`release/action.yml\` with \`@action-validator/cli\` — exit 0.
- [x] Confirmed the awk extraction handles both head-of-file and middle-of-file \`## <version>\` sections (single-section and multi-section CHANGELOGs).
- [x] Confirmed bash parameter expansion correctly splits \`@scope/pkg@x.y.z-alpha.n\` into name/version even with the leading-\`@\` scope.
- [ ] First real-world exercise will be \`stridge-foundation/kit\`'s release pipeline, which consumes this action at \`@main\`. The downstream PR removes its local workaround once this merges.