### PR TITLE
Add `pnpm-cache` and `playwright-cache` inputs to `e2e-test-runner`

### DIFF
--- a/e2e-bootstrap/README.md
+++ b/e2e-bootstrap/README.md
@@ -57,13 +57,15 @@ jobs:
             - uses: actions/checkout@v6
             - uses: technance-foundation/github-actions/e2e-test-runner@main
               with:
-                  # ... shard inputs as usual. pnpm + browser caches
-                  # are already populated, so the runner's own setup
-                  # steps will restore them instead of installing.
-                  ...
+                  # ... shard inputs as usual ...
+                  # Both caches are already populated by `bootstrap`;
+                  # mark them read-only so each shard skips ~60s of
+                  # post-job tar/save work on caches that already exist.
+                  pnpm-cache: "read"
+                  playwright-cache: "read"
 ```
 
-Pair with `strategy.fail-fast: true` at the matrix level so a failing shard cancels its siblings — bootstrap on its own only addresses duplicated *setup* time, not duplicated *test* time after a failure.
+Pair with `strategy.fail-fast: true` at the matrix level so a failing shard cancels its siblings — bootstrap on its own only addresses duplicated *setup* time, not duplicated *test* time after a failure. And pair with `pnpm-cache: "read"` + `playwright-cache: "read"` on the shards (shown above) so the cache-write half of the per-shard cycle is skipped too — without that, every shard still spends ~60s tar-ing a cache it never gets to upload.
 
 ## Why not put this in `e2e-test-runner`?
 

--- a/e2e-test-runner/README.md
+++ b/e2e-test-runner/README.md
@@ -39,6 +39,8 @@ If you’re curious how that works, see: [RELAY.md](../RELAY.md)
 | `shard-index`          | –        | 1-based shard index. When set together with `shard-total`, the action runs Playwright in shard mode (see below). |
 | `shard-total`          | –        | Total number of shards. Required alongside `shard-index` to enable shard mode. |
 | `skip-check-completion` | –        | When `'true'`, the action does not mark the GitHub check as completed at the end of the job. Use this when a downstream merge job owns the final check status. |
+| `pnpm-cache`           | –        | pnpm-store cache strategy. `write` (default) restores + saves; `read` restores only; `off` disables the cache. Set to `read` on shards that follow an `e2e-bootstrap` job (see below). |
+| `playwright-cache`     | –        | Playwright browser cache strategy. `write` (default) restores + saves; `read` restores only. Set to `read` on shards that follow an `e2e-bootstrap` job. |
 
 ---
 
@@ -155,16 +157,33 @@ When `shard-index` AND `shard-total` are both set:
 - `--shard=<index>/<total>` is appended to `test-command` (after `--`, so wrapper scripts that respect `--` get the flag).
 - The Playwright config is expected to use the [`blob` reporter](https://playwright.dev/docs/test-reporters#blob-reporter) writing to `blob-report/`.
 - Instead of uploading `playwright-report/`, the action uploads `blob-report/` as `<project>-playwright-blob-report-<shard-index>` so a merge job can pick the artifacts up by glob.
-- If `skip-check-completion: "true"` is also set, the action skips `e2e-check@v1 state: completed` so the merge job can finalize the check exactly once (4 shards otherwise race PATCH `/check-runs` with conflicting outcomes).
+- If `skip-check-completion: "true"` is also set, the action skips `e2e-check@main state: completed` so the merge job can finalize the check exactly once (4 shards otherwise race PATCH `/check-runs` with conflicting outcomes).
+
+### Pairing with `e2e-bootstrap` (read-only caches on shards)
+
+When the matrix is preceded by an [`e2e-bootstrap`](../e2e-bootstrap/README.md) job that primes the pnpm store + Playwright browser caches, every shard then sees both caches as already-existing. The shards should pass `pnpm-cache: "read"` and `playwright-cache: "read"` so they only **restore** the caches — they don't waste ~30–60s of post-job time tar-ing and trying to save the same content. The save itself is a no-op (GHA dedupes by key), but the tar/upload-prep work still runs on every shard unless you opt out.
 
 ### Caller workflow example
 
 ```yaml
 jobs:
+    bootstrap:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1
+
+            - uses: technance-foundation/github-actions/e2e-bootstrap@main
+              with:
+                  node-version: "24"
+                  pnpm-version: "11.0.9"
+
     test-e2e-sharded:
+        needs: bootstrap
         runs-on: 8core-linux-x64-ubuntu-latest
         strategy:
-            fail-fast: false
+            fail-fast: true
             matrix:
                 shard: [1, 2, 3, 4]
         steps:
@@ -188,12 +207,15 @@ jobs:
                   check-run-id: ${{ inputs.check_run_id }}
                   project: ${{ inputs.project }}
                   preview-url: ${{ inputs.url }}
-                  npm-token: ${{ secrets.NPM_TOKEN }}
                   working-directory: ${{ inputs.working_directory }}
                   test-command: ${{ inputs.test_command }}
                   shard-index: ${{ matrix.shard }}
                   shard-total: ${{ strategy.job-total }}
                   skip-check-completion: "true"
+                  # Caches were written once by `bootstrap`; shards
+                  # just restore them — saves ~60s post-job per shard.
+                  pnpm-cache: "read"
+                  playwright-cache: "read"
 
     e2e-merge:
         runs-on: ubuntu-latest

--- a/e2e-test-runner/action.yml
+++ b/e2e-test-runner/action.yml
@@ -58,6 +58,16 @@ inputs:
         description: "If 'true', the runner does not mark the GitHub check as completed at the end of the job. Use this when a downstream merge job is responsible for completing the check (e.g. after merging blob reports from multiple shards)."
         required: false
         default: "false"
+
+    pnpm-cache:
+        description: "pnpm-store cache strategy. `write` (default) restores and saves; `read` restores only — set this on shards that follow an `e2e-bootstrap` job so they don't waste post-job time re-tarring the same store; `off` disables the cache entirely."
+        required: false
+        default: "write"
+
+    playwright-cache:
+        description: "Playwright browser cache strategy. `write` (default) restores and saves; `read` restores only — set this on shards that follow an `e2e-bootstrap` job so they don't waste post-job time re-tarring the browser cache."
+        required: false
+        default: "write"
 runs:
     using: composite
     steps:
@@ -101,21 +111,51 @@ runs:
               node-version: ${{ inputs.node-version }}
               pnpm-version: ${{ inputs.pnpm-version }}
               npm-token: ${{ inputs.npm-token }}
-              pnpm-cache: "write"
+              pnpm-cache: ${{ inputs.pnpm-cache }}
               install: "pnpm install --no-frozen-lockfile"
               build: "false"
 
         # -----------------------------------------------------
         # BROWSER CACHING
         # -----------------------------------------------------
-        - name: Cache Playwright browsers
-          id: cache-playwright
+        # Two conditional cache steps: `actions/cache@v5` (read +
+        # write — default) vs `actions/cache/restore@v4` (read
+        # only). The downstream `cache-playwright` step normalizes
+        # the `cache-hit` output so the install-on-miss step and
+        # the final `Complete check` job-status expression don't
+        # need to branch on which one ran.
+        - name: Cache Playwright browsers (read + write)
+          id: cache-playwright-rw
+          if: inputs.playwright-cache != 'read'
           uses: actions/cache@v5
           with:
               path: ~/.cache/ms-playwright
               key: ${{ runner.os }}-playwright-${{ inputs.playwright-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
               restore-keys: |
                   ${{ runner.os }}-playwright-${{ inputs.playwright-version }}-
+
+        - name: Cache Playwright browsers (restore only)
+          id: cache-playwright-ro
+          if: inputs.playwright-cache == 'read'
+          uses: actions/cache/restore@v4
+          with:
+              path: ~/.cache/ms-playwright
+              key: ${{ runner.os }}-playwright-${{ inputs.playwright-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+              restore-keys: |
+                  ${{ runner.os }}-playwright-${{ inputs.playwright-version }}-
+
+        - name: Normalize Playwright cache-hit
+          id: cache-playwright
+          shell: bash
+          env:
+              HIT_RW: ${{ steps.cache-playwright-rw.outputs.cache-hit }}
+              HIT_RO: ${{ steps.cache-playwright-ro.outputs.cache-hit }}
+          run: |
+              if [ "$HIT_RW" = "true" ] || [ "$HIT_RO" = "true" ]; then
+                  echo "cache-hit=true" >> "$GITHUB_OUTPUT"
+              else
+                  echo "cache-hit=false" >> "$GITHUB_OUTPUT"
+              fi
 
         - name: Install Playwright deps + browsers (cache miss)
           id: pw-install


### PR DESCRIPTION
## Summary

Adds two new optional inputs on `e2e-test-runner` so matrix shards that follow an `e2e-bootstrap` job can mark their caches as **read-only**, skipping the ~60s/shard post-job tar pass that today produces an upload GHA immediately discards as a duplicate-key no-op.

| Input | Default | Read-only effect |
| --- | --- | --- |
| `pnpm-cache` | `"write"` (unchanged) | Forwarded to the existing `setup` action's `pnpm-cache` input. `"read"` restores the pnpm store but skips the save step. |
| `playwright-cache` | `"write"` (unchanged) | Selects `actions/cache@v5` (write) vs `actions/cache/restore@v4` (read-only). The restore-only action has no post-hook, so the tar pass at job end is skipped entirely. |

Existing callers that don't specify either input get **identical behavior to before**.

## Why

On the [most recent midnight E2E run](https://github.com/technance-foundation/technance-platform-frontend/actions/runs/25725492763), each shard's post-job step was ~60s — that's GHA tar-ing `node_modules` + `~/.cache/ms-playwright` so it can call the cache-save API, which then no-ops because the bootstrap job already wrote the same key. Across 4 shards that's ~4 wasted CI minutes per run. With `cache: "read"`, the post-hook itself doesn't register on the runner, so the tar never happens.

## Implementation detail worth flagging in review

The Playwright cache had to become two conditional steps (`actions/cache@v5` vs `actions/cache/restore@v4`) because the two actions don't share a post-hook toggle. A small normalizer step republishes the union of their `cache-hit` outputs under the existing `steps.cache-playwright.outputs.cache-hit` ID, so:

- The downstream "Install Playwright deps + browsers (cache miss)" condition keeps working without change.
- The final "Complete check" `job-status` expression keeps referencing `steps.cache-playwright.outcome` without change.

This means consumers who currently inspect `steps.cache-playwright` outputs (none that I know of, but flagging) continue to work.

## Test plan

- A consumer workflow using the existing `e2e-bootstrap` job + `e2e-test-runner@main` without passing the new inputs should observe **no behavioral change** (defaults are `"write"`).
- A consumer that adds `pnpm-cache: "read"` + `playwright-cache: "read"` on its shards should observe:
  - Bootstrap writes both caches (unchanged).
  - Each shard's "Cache Playwright browsers (read + write)" step is skipped; the "(restore only)" step runs and reports `cache-hit: true`.
  - Each shard's `setup` action restores the pnpm store but skips its post-save.
  - Post-job duration drops from ~60s to a few seconds.

## Follow-up

Companion change in the frontend repo's workflow will set the two new inputs on its sharded matrix to exercise the read-only path end-to-end.
