### PR TITLE
Bump deprecated Node 20 third-party actions to Node 24 versions

### DIFF
--- a/ai-translation-pr/action.yml
+++ b/ai-translation-pr/action.yml
@@ -211,7 +211,7 @@ runs:
 
         - name: Upload Worphling reports
           if: ${{ always() && steps.detect.outputs.affected_count != '0' }}
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
               name: worphling-ai-translation-pr-${{ inputs.pr-number }}-reports
               path: ${{ inputs.artifact-root }}/

--- a/e2e-check/action.yml
+++ b/e2e-check/action.yml
@@ -74,7 +74,7 @@ runs:
         # DEBUG 3: Ensure check run exists
         # -----------------------------
         - name: DEBUG — Validate Check Run Exists
-          uses: actions/github-script@v8
+          uses: actions/github-script@v9
           env:
               CHECK_RUN_ID: ${{ inputs.check-run-id }}
           with:
@@ -106,7 +106,7 @@ runs:
         # -----------------------------
         - name: Mark check as in_progress
           if: ${{ inputs.state == 'in_progress' }}
-          uses: actions/github-script@v8
+          uses: actions/github-script@v9
           env:
               CHECK_RUN_ID: ${{ inputs.check-run-id }}
           with:
@@ -117,7 +117,7 @@ runs:
 
         - name: Complete check
           if: ${{ inputs.state == 'completed' }}
-          uses: actions/github-script@v8
+          uses: actions/github-script@v9
           env:
               CHECK_RUN_ID: ${{ inputs.check-run-id }}
               PROJECT: ${{ inputs.project }}

--- a/e2e-test-runner/README.md
+++ b/e2e-test-runner/README.md
@@ -189,10 +189,10 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - id: app-token
-              uses: tibdex/github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
-                  app_id: ${{ vars.E2E_RELAY_GH_APP_ID }}
-                  private_key: ${{ secrets.E2E_RELAY_GH_APP_PRIVATE_KEY }}
+                  app-id: ${{ vars.E2E_RELAY_GH_APP_ID }}
+                  private-key: ${{ secrets.E2E_RELAY_GH_APP_PRIVATE_KEY }}
 
             - uses: technance-foundation/github-actions/e2e-test-runner@main
               env:
@@ -224,10 +224,10 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - id: app-token
-              uses: tibdex/github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
-                  app_id: ${{ vars.E2E_RELAY_GH_APP_ID }}
-                  private_key: ${{ secrets.E2E_RELAY_GH_APP_PRIVATE_KEY }}
+                  app-id: ${{ vars.E2E_RELAY_GH_APP_ID }}
+                  private-key: ${{ secrets.E2E_RELAY_GH_APP_PRIVATE_KEY }}
 
             - uses: technance-foundation/github-actions/setup@main
               with:
@@ -241,7 +241,7 @@ jobs:
             - run: mkdir -p all-blob-reports
               shell: bash
 
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
               with:
                   pattern: ${{ inputs.project }}-playwright-blob-report-*
                   path: all-blob-reports
@@ -261,7 +261,7 @@ jobs:
                       --reporter=list,html,junit \
                       "${{ github.workspace }}/all-blob-reports"
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v7
               if: ${{ always() }}
               with:
                   name: ${{ inputs.project }}-playwright-report

--- a/e2e-test-runner/action.yml
+++ b/e2e-test-runner/action.yml
@@ -119,7 +119,7 @@ runs:
         # BROWSER CACHING
         # -----------------------------------------------------
         # Two conditional cache steps: `actions/cache@v5` (read +
-        # write — default) vs `actions/cache/restore@v4` (read
+        # write — default) vs `actions/cache/restore@v5` (read
         # only). The downstream `cache-playwright` step normalizes
         # the `cache-hit` output so the install-on-miss step and
         # the final `Complete check` job-status expression don't
@@ -137,7 +137,7 @@ runs:
         - name: Cache Playwright browsers (restore only)
           id: cache-playwright-ro
           if: inputs.playwright-cache == 'read'
-          uses: actions/cache/restore@v4
+          uses: actions/cache/restore@v5
           with:
               path: ~/.cache/ms-playwright
               key: ${{ runner.os }}-playwright-${{ inputs.playwright-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -190,7 +190,7 @@ runs:
         - name: Upload Playwright blob report (sharded)
           id: upload-blob-report
           if: always() && inputs.shard-index != '' && inputs.shard-total != ''
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
               name: ${{ inputs.project }}-playwright-blob-report-${{ inputs.shard-index }}
               path: ${{ inputs.working-directory != '' && format('{0}/blob-report/', inputs.working-directory) || format('apps/{0}/blob-report/', inputs.project) }}
@@ -200,7 +200,7 @@ runs:
         - name: Upload Playwright report (un-sharded)
           id: upload-report
           if: always() && (inputs.shard-index == '' || inputs.shard-total == '')
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
               name: ${{ inputs.project }}-playwright-report
               path: ${{ inputs.working-directory != '' && format('{0}/playwright-report/', inputs.working-directory) || format('apps/{0}/playwright-report/', inputs.project) }}

--- a/publish-any-commit/action.yml
+++ b/publish-any-commit/action.yml
@@ -93,7 +93,7 @@ runs:
               ref: ${{ inputs.ref }}
 
         - name: Setup pnpm
-          uses: pnpm/action-setup@v4
+          uses: pnpm/action-setup@v6
           with:
               version: ${{ inputs.pnpm-version }}
               run_install: false

--- a/release/action.yml
+++ b/release/action.yml
@@ -107,7 +107,7 @@ runs:
               git config --global user.name "${{ inputs.git-user-name }}"
 
         - name: Setup pnpm
-          uses: pnpm/action-setup@v4
+          uses: pnpm/action-setup@v6
           with:
               version: ${{ inputs.pnpm-version }}
               run_install: false

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -33,7 +33,7 @@ runs:
           with:
               node-version: ${{ inputs.node-version }}
 
-        # `pnpm/action-setup@v4` errors when both its `version` input and the
+        # `pnpm/action-setup@v6` errors when both its `version` input and the
         # `packageManager` field in `package.json` are set and disagree. Defer
         # to `packageManager` whenever it pins a pnpm version so the install
         # always matches the checked-out lockfile; fall back to the input only
@@ -58,14 +58,14 @@ runs:
 
         - name: Setup pnpm (from `packageManager` field)
           if: ${{ steps.pnpm-source.outputs.from_package_json == 'true' }}
-          uses: pnpm/action-setup@v4
+          uses: pnpm/action-setup@v6
           with:
               run_install: false
               package_json_file: ${{ steps.pnpm-source.outputs.package_json_file }}
 
         - name: Setup pnpm (from `pnpm-version` input)
           if: ${{ steps.pnpm-source.outputs.from_package_json == 'false' }}
-          uses: pnpm/action-setup@v4
+          uses: pnpm/action-setup@v6
           with:
               version: ${{ inputs.pnpm-version }}
               run_install: false
@@ -79,7 +79,7 @@ runs:
               pnpm store path >> "$GITHUB_OUTPUT"
               echo "EOF" >> "$GITHUB_OUTPUT"
 
-        - uses: actions/cache/restore@v4
+        - uses: actions/cache/restore@v5
           if: ${{ inputs.pnpm-cache == 'read' }}
           name: Initialize pnpm cache
           with:
@@ -89,7 +89,7 @@ runs:
                   ${{ runner.os }}-node-${{ inputs.node-version }}-pnpm-store-${{ hashFiles(format('{0}/**/package.json', inputs.working-directory)) }}-
                   ${{ runner.os }}-node-${{ inputs.node-version }}-pnpm-store-
 
-        - uses: actions/cache@v4
+        - uses: actions/cache@v5
           if: ${{ inputs.pnpm-cache == 'write' }}
           name: Initialize pnpm cache
           with:


### PR DESCRIPTION
## Summary

GitHub Actions has scheduled Node 20 action runtime deprecation. Runs against `@v4`-class actions now emit warnings like:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/cache@v4`, `actions/cache/restore@v4`, `actions/upload-artifact@v4`, `pnpm/action-setup@v4` ...

This PR bumps every flagged third-party action in this repo to its latest Node-24 release in one sweep, and updates the `e2e-test-runner` README's caller-workflow example so consumers copy-pasting from it don't reintroduce the same warnings.

## `action.yml` bumps

| Action | Before | After | Where |
| --- | --- | --- | --- |
| `actions/cache` | `@v4` | `@v5` | `setup/action.yml` |
| `actions/cache/restore` | `@v4` | `@v5` | `setup/action.yml`, `e2e-test-runner/action.yml` |
| `actions/upload-artifact` | `@v4` | `@v7` | `ai-translation-pr/action.yml`, `e2e-test-runner/action.yml` (×2) |
| `actions/github-script` | `@v8` | `@v9` | `e2e-check/action.yml` (×3) |
| `pnpm/action-setup` | `@v4` | `@v6` | `setup/action.yml` (×2), `release/action.yml`, `publish-any-commit/action.yml` |

`actions/cache@v5`, `actions/cache/restore@v5`, and `actions/upload-artifact@v7` were already in use in this repo (in `e2e-bootstrap` and the `e2e-test-runner` cache step). The bumps bring the remaining holdouts into line so every action.yml is on Node 24.

## README example bumps

`e2e-test-runner/README.md` showed a caller-workflow example with three Node-20-class third-party actions. Bumped to match:

| Action | Before | After |
| --- | --- | --- |
| GH App token | `tibdex/github-app-token@v2` (Node 20, unmaintained) | `actions/create-github-app-token@v3` (Node 24, official) |
| `actions/download-artifact` | `@v4` | `@v8` |
| `actions/upload-artifact` | `@v4` | `@v7` |

The token-action swap also renames the inputs in the example (`app_id` → `app-id`, `private_key` → `private-key`). Secrets and the `token` output stay the same.

No other README in this repo references a Node-20-class third-party action version.

## Compatibility

All five `action.yml` bumps preserve the input shapes this repo uses:

- `actions/cache` v5 — same `path` / `key` / `restore-keys` / `cache-hit` contract as v4.
- `actions/upload-artifact` v5+ already inherits v4's required-`name` and immutable-artifact rules, so the `name: <project>-playwright-{blob-,}report-*` we already emit is unchanged.
- `actions/github-script` v9 keeps the `script:` API.
- `pnpm/action-setup` v6 keeps the `version` and `run_install` inputs the `setup` action's two conditional steps consume.

## Left alone on purpose

- `appleboy/telegram-action@master` in `telegram-notifications/action.yml` — that's a separate pinning antipattern (`@master`, not a Node 20 deprecation). Out of scope.

## Companion PR

The consumer workflow in `technance-platform-frontend` has its own Node 20 holdouts that this repo can't reach: `tibdex/github-app-token@v2` (×3), `actions/download-artifact@v4`, and `actions/upload-artifact@v4` directly in `.github/workflows/e2e.yaml`. Those are bumped in **technance-platform-frontend#3301** alongside this PR.
